### PR TITLE
Adopt org secrets management standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pnpm build        # prebuild (ensure-ops-data) → vite build
 ## Where to read
 
 - `CLAUDE.md` — agent rules, working-with-Adrian conventions, dispatch rules (start here).
+- `standards/secrets-management.md` — **org-wide Secrets Management Standard** (canonical home; every Hirobius repo links here). Fleet adoption tracked in `standards/secrets-adoption.md`.
 - `docs/ai/HANDOFF.md` — current state / what's next.
 - `docs/ai/NORTH_STAR.md` — the focus contract (scope guard).
 - `docs/ARCHITECTURE.md` — the lead → site delivery pipeline + decisions.

--- a/standards/secrets-adoption.md
+++ b/standards/secrets-adoption.md
@@ -1,0 +1,43 @@
+# Secrets Standard — Fleet Adoption Tracker
+
+Tracks adoption of the [Hirobius Secrets Management Standard](./secrets-management.md)
+across every Hirobius repo. Canonical doc lives here in `hirobius/ops`; each repo
+gets a tracking issue ("Adopt secrets standard: &lt;repo&gt;") linking back to it.
+
+**Status legend:** `compliant` · `in-progress` · `not-started` · `n/a (no secrets)` · `excluded (legacy)`
+
+## Active fleet
+
+| Repo | Status | Owner-classification done | History-scanned | Tracking issue | Notes |
+|------|--------|:--:|:--:|--|-------|
+| `hirobius/ops` | in-progress | — | — | — | This repo — canonical home of the standard. Secrets are Hirobius-Internal (ops gate, Supabase, GITHUB_TOKEN, Outscraper, portal HMAC). Needs `.env.example` (names-only) authored. |
+| `hirobius/lilac-insure` | **compliant** | ✅ | ✅ | — | Reference implementation — first client fully on the standard. Do not redo. |
+| `hirobius/clients` | not-started | ☐ | ☐ | — | Astro site factory — likely holds build/deploy + per-client keys. |
+| `hirobius/concrete` | not-started | ☐ | ☐ | — | Concrete Creations storefront — Stripe keys + Discord webhook (see concrete#4). |
+| `hirobius/portfolio` | not-started | ☐ | ☐ | — | adrianmilsap.com (Next.js). |
+| `hirobius/hirobius-design-system` | not-started | ☐ | ☐ | — | Publishable DS — CI likely uses Chromatic + npm publish tokens. |
+| `hirobius/lilac-bonds` | not-started | ☐ | ☐ | — | Lilac bond microsite. Owner = Lilac. |
+| `hirobius/access-tech` | not-started | ☐ | ☐ | — | Client site. |
+| `hirobius/veteran-resource-navigator` | not-started | ☐ | ☐ | — | Client site. |
+| `hirobius/job-hunt` | not-started | ☐ | ☐ | — | Internal tool. |
+| `hirobius/adrian-milsap` | not-started | ☐ | ☐ | — | Older portfolio — low priority; may be retired. |
+| `hirobius/Hdshub` | not-started | ☐ | ☐ | — | Figma Make experiment — low priority. |
+| `hirobius/ops-archive` | not-started | ☐ | ☐ | — | Retired old ops tracker — likely `n/a`; confirm + archive. |
+| `hirobius/dotfiles` | not-started | ☐ | ☐ | — | Private personal config — review for embedded secrets. |
+
+## Excluded (legacy — pre-2026 bootcamp / practice repos, no active deployment or secrets)
+
+`301-*`, `city-explorer`, `city-explorer-api`, `cookie-stand`, `bus-mall`,
+`memory-game`, `data-structures-and-algorithms`, `best-books-front-end`, `horns`,
+`kims`, `doAlong`, `about-me`, `wireframe-exercise`, `mc-exercise`, `lab14`,
+`basic-express-server`, `server-deployment-practice`, `reading-notes`,
+`portfolio-temp`, `portfolio-archive`, `Medford`, `Testclaude`.
+
+Rationale: all created 2020–2021 as learning/lab projects, not deployed agency
+work, no live credentials. Revisit only if any is reactivated.
+
+---
+
+_Updated as inventory + per-repo adoption proceeds. Each `not-started` row moves to
+`in-progress` when its tracking issue is opened, then `compliant` when its
+checklist is satisfied._

--- a/standards/secrets-adoption.md
+++ b/standards/secrets-adoption.md
@@ -2,28 +2,30 @@
 
 Tracks adoption of the [Hirobius Secrets Management Standard](./secrets-management.md)
 across every Hirobius repo. Canonical doc lives here in `hirobius/ops`; each repo
-gets a tracking issue ("Adopt secrets standard: &lt;repo&gt;") linking back to it.
+has a tracking issue ("Adopt secrets standard: &lt;repo&gt;") linking back to it.
 
 **Status legend:** `compliant` · `in-progress` · `not-started` · `n/a (no secrets)` · `excluded (legacy)`
 
+_Inventory pass: 2026-07-06 (static scan of `.env.example` / tracked env files / `.gitignore` / CI config via GitHub API). **No leaked secrets or committed values found in any repo.** "History-scanned" = a full gitleaks/trufflehog history pass; only `ops` has had even a heuristic history scan so far._
+
 ## Active fleet
 
-| Repo | Status | Owner-classification done | History-scanned | Tracking issue | Notes |
-|------|--------|:--:|:--:|--|-------|
-| `hirobius/ops` | in-progress | — | — | — | This repo — canonical home of the standard. Secrets are Hirobius-Internal (ops gate, Supabase, GITHUB_TOKEN, Outscraper, portal HMAC). Needs `.env.example` (names-only) authored. |
-| `hirobius/lilac-insure` | **compliant** | ✅ | ✅ | — | Reference implementation — first client fully on the standard. Do not redo. |
-| `hirobius/clients` | not-started | ☐ | ☐ | — | Astro site factory — likely holds build/deploy + per-client keys. |
-| `hirobius/concrete` | not-started | ☐ | ☐ | — | Concrete Creations storefront — Stripe keys + Discord webhook (see concrete#4). |
-| `hirobius/portfolio` | not-started | ☐ | ☐ | — | adrianmilsap.com (Next.js). |
-| `hirobius/hirobius-design-system` | not-started | ☐ | ☐ | — | Publishable DS — CI likely uses Chromatic + npm publish tokens. |
-| `hirobius/lilac-bonds` | not-started | ☐ | ☐ | — | Lilac bond microsite. Owner = Lilac. |
-| `hirobius/access-tech` | not-started | ☐ | ☐ | — | Client site. |
-| `hirobius/veteran-resource-navigator` | not-started | ☐ | ☐ | — | Client site. |
-| `hirobius/job-hunt` | not-started | ☐ | ☐ | — | Internal tool. |
-| `hirobius/adrian-milsap` | not-started | ☐ | ☐ | — | Older portfolio — low priority; may be retired. |
-| `hirobius/Hdshub` | not-started | ☐ | ☐ | — | Figma Make experiment — low priority. |
-| `hirobius/ops-archive` | not-started | ☐ | ☐ | — | Retired old ops tracker — likely `n/a`; confirm + archive. |
-| `hirobius/dotfiles` | not-started | ☐ | ☐ | — | Private personal config — review for embedded secrets. |
+| Repo | Status | Owner | Owner-classified | History-scanned | Tracking issue | Notes |
+|------|--------|-------|:--:|:--:|--|-------|
+| `hirobius/lilac-insure` | **compliant** | client (Lilac) | ✅ | ✅ | — | Reference implementation — first client fully on the standard. Do not redo. |
+| `hirobius/veteran-resource-navigator` | in-progress (near) | client / pro-bono | ✅ | ☐ | [#45](https://github.com/hirobius/veteran-resource-navigator/issues/45) | `.env.example` names-only ✅, `.gitignore` ✅. CI secret `PARTNERS_SHEET_CSV_URL`. Just needs Bitwarden classification + history scan. |
+| `hirobius/job-hunt` | in-progress (near) | Internal | ✅ | ☐ | [#22](https://github.com/hirobius/job-hunt/issues/22) | `.env.example` uses `sk-ant-...` placeholder → change to bare name; broaden `.gitignore` to `.env*`. `ANTHROPIC_API_KEY` only. |
+| `hirobius/ops` | in-progress | Internal | ✅ | ✅ (heuristic, clean) | [#32](https://github.com/hirobius/ops/issues/32) | Canonical home. `.gitignore` ✅. Needs names-only `.env.example` (paste-ready in #32). CI secrets: `FIGMA_FILE_KEY`, `FIGMA_PERSONAL_ACCESS_TOKEN`. |
+| `hirobius/hirobius-design-system` | in-progress | Internal | ✅ | ☐ | [#86](https://github.com/hirobius/hirobius-design-system/issues/86) | No runtime secrets; CI-only `CHROMATIC_PROJECT_TOKEN`, `NPM_TOKEN`. Needs Bitwarden classification; `.env.example` optional. |
+| `hirobius/clients` | in-progress | multi-client ⚠️ | ✅ | ☐ | [#27](https://github.com/hirobius/clients/issues/27) | **Highest cross-contamination risk** (multi-tenant monorepo). Needs `apps/_template/.env.example` + strict per-app owner split. `.gitignore` ✅. |
+| `hirobius/concrete` | in-progress | client (Concrete) | ✅ | ☐ | [#7](https://github.com/hirobius/concrete/issues/7) | Needs names-only `.env.example` (`STRIPE_*`, `DISCORD_SALES_WEBHOOK_URL`, `VITE_SITE_URL`). `.gitignore` ✅. |
+| `hirobius/lilac-bonds` | in-progress | client (Lilac) | ✅ | ☐ | [#21](https://github.com/hirobius/lilac-bonds/issues/21) | `.gitignore` ✅ (has `!.env.example` exception but file absent). Confirm `process.env` use, then add `.env.example` or mark `n/a`. |
+| `hirobius/portfolio` | n/a (no secrets) | Internal | ✅ | ☐ | [#10](https://github.com/hirobius/portfolio/issues/10) | No `process.env` usage. `.gitignore` = Next default (`.env*.local`). Revisit if env vars added. |
+| `hirobius/access-tech` | n/a (no secrets) | client | ✅ | ☐ | [#15](https://github.com/hirobius/access-tech/issues/15) | Static marketing site, no secrets surface. No `.gitignore` at all — issue recommends a preemptive one. |
+| `hirobius/adrian-milsap` | not-started (deferred) | Internal | ☐ | ☐ | — | Older portfolio, likely retired — inventory deferred (low priority). |
+| `hirobius/Hdshub` | not-started (deferred) | Internal | ☐ | ☐ | — | Figma Make experiment — inventory deferred (low priority). |
+| `hirobius/ops-archive` | not-started (deferred) | Internal | ☐ | ☐ | — | Retired old ops tracker — likely `n/a`; confirm + archive. |
+| `hirobius/dotfiles` | not-started (deferred) | Internal | ☐ | ☐ | — | Private personal config — review for embedded secrets before closing. |
 
 ## Excluded (legacy — pre-2026 bootcamp / practice repos, no active deployment or secrets)
 
@@ -36,8 +38,12 @@ gets a tracking issue ("Adopt secrets standard: &lt;repo&gt;") linking back to i
 Rationale: all created 2020–2021 as learning/lab projects, not deployed agency
 work, no live credentials. Revisit only if any is reactivated.
 
+## How the columns move
+
+- **Owner-classified ✅** = the owner (Internal vs which client) is determined. Moving the secret into the right **Bitwarden collection** is the human step tracked in each issue.
+- **History-scanned ✅** = a full gitleaks/trufflehog pass over all history came back clean (or leaks were rotated + purged). `ops` has a heuristic pass only; the rest are pending.
+- A repo reaches **compliant** when its tracking-issue checklist is fully satisfied.
+
 ---
 
-_Updated as inventory + per-repo adoption proceeds. Each `not-started` row moves to
-`in-progress` when its tracking issue is opened, then `compliant` when its
-checklist is satisfied._
+_Updated 2026-07-06. Agents don't create `.env*` files (Hirobius rule: keys/env files are human-managed); per-repo `.env.example` content is provided paste-ready in each tracking issue for a human to commit._

--- a/standards/secrets-management.md
+++ b/standards/secrets-management.md
@@ -1,0 +1,152 @@
+# Hirobius Secrets Management Standard
+
+> **Scope:** every Hirobius repo and every client engagement. This is the one
+> way we store, name, scope, and deploy secrets. Its job is to make
+> cross-contamination structurally impossible — a key is always owned by exactly
+> one party and lives in exactly one place.
+>
+> **Canonical home:** this file, in **`hirobius/ops`** (`standards/secrets-management.md`),
+> is the authoritative copy. Every other repo links here rather than forking the
+> text. Adoption across the fleet is tracked in
+> [`secrets-adoption.md`](./secrets-adoption.md). Reference implementation:
+> `hirobius/lilac-insure` (the first client fully on the standard).
+
+## Principles
+
+1. **Bitwarden is the single source of truth.** Repos never contain secret
+   *values* — only the env-var *names*.
+2. **Every secret has exactly one owner:** either **Internal (Hirobius)** or **a
+   specific client**. Never both. A key used by both is a smell — split it.
+3. **Least privilege.** One scoped credential per system per client; a dedicated
+   read-only / integration user wherever the vendor allows it.
+4. **`.env.local` is a machine-local copy** populated from Bitwarden, never
+   committed. Servers/CI inject from the secrets manager, not from files.
+
+## Bitwarden structure (the isolation boundary)
+
+Use a Bitwarden **Organization**. **Collections are the boundary** that stops
+cross-contamination:
+
+- **One collection per client** — `Lilac Insurance`, `Acme Co`, …
+- **One `Hirobius — Internal` collection** for your own infra/dev/tooling keys
+  (GitHub PATs, Vercel, domain, CI, etc.).
+- Share a client collection **only** with the people who operate that client.
+  (No Org yet? Use a **Folder** per owner as the poor-man's version — same
+  naming, weaker isolation.)
+
+## Item convention
+
+- **One item per credential *set*** (per system) — never one mega-note.
+- **Item name:** `<Owner> — <System> — <purpose>`
+  - `Lilac — EZLynx API`
+  - `Lilac — Gravity Forms REST (read-only)`
+  - `Hirobius — GitHub PAT (packages)`
+- **Custom fields = env-var names.** Store each value in a field whose label is
+  the *exact* env-var name, so it maps 1:1 into `.env.local`:
+  - `Lilac — EZLynx API` → `EZLYNX_API_URL`, `EZ_USER`, `EZ_PASSWORD`, `EZ_APP_SECRET`
+  - `Lilac — Microsoft Graph app` → `MS_GRAPH_TENANT_ID`, `MS_GRAPH_CLIENT_ID`, `MS_GRAPH_CLIENT_SECRET`
+- **Notes field records:** which repo(s)/machine(s) it's deployed to, created
+  date, last-rotated date, and the permission scope granted.
+
+### Which Bitwarden item type
+
+| What you're storing | Item type |
+|---------------------|-----------|
+| **SSH private key** (git / server auth) | **SSH Key** item — used via the Bitwarden SSH agent, so the key authenticates without ever being copied to disk. |
+| **API keys / tokens / client secrets / env-var values** | **Login** item with **hidden** custom fields (label = env-var name; base URL in the URI slot). Field masking + searchable. |
+| Genuinely unstructured misc | Secure Note (fallback only). |
+
+- **SSH private keys never go in a Secure Note** — use the SSH Key item type.
+- **API secrets never go in the SSH agent** — it's for SSH keys only; use a Login
+  item with hidden fields.
+- Reserve Secure Notes for truly unstructured content — no field masking, easy to
+  fat-finger.
+
+## The repo contract
+
+- Repo holds **only env-var names** in `.env.example`, with a one-line comment on
+  where each is obtained.
+- Real values live in `.env.local`, gitignored via `.env`, `.env.local`,
+  `.env.*.local`.
+- **Nothing secret is ever committed, pasted into chat/AI, or emailed.**
+
+## Cloud / Claude Code environments (no local machine)
+
+When you work entirely in the cloud (Claude Code on the web, long-running remote
+environments), the container is ephemeral and there's no durable local disk — so
+**don't hand-manage a `.env.local` file inside it.** Instead:
+
+- **Set secrets as the environment's configured environment variables** (the
+  Claude Code environment's env-var settings). Every session then has them in
+  `process.env`, and our loaders read `process.env` directly — no file to manage,
+  nothing to commit. (`loadEnvLocal()` only fills vars that aren't already set,
+  so environment-provided values win and a `.env.local` becomes optional.)
+- **Or inject at session start:** a setup script / SessionStart hook that pulls
+  from your secrets manager (Bitwarden CLI `bw`, Doppler `doppler run`, 1Password
+  `op`) and exports the vars — so any `.env.local` is generated fresh each
+  session and never persists or gets committed.
+- **One environment per owner.** Never put two clients' secrets in the same cloud
+  environment — same isolation rule as Bitwarden collections. A Lilac environment
+  holds only Lilac's keys.
+
+### The dev-vs-production boundary (important)
+
+A cloud build/dev environment is the right home for **test / dev-tenant
+credentials** while building. It is **not** where production automations that
+touch real client PII should run. Per each client's architecture, the live
+workflows run on the **client's own infrastructure** (their PC / VPS) so client
+data never leaves it. Keep **test creds** (cloud dev env) and **production creds**
+(client infra) as separate Bitwarden items, and never load a client's production
+keys into a shared cloud environment.
+
+## Transferring a secret
+
+Use **Bitwarden Send** (one-time, expiring link) to hand a secret to or from a
+client. Never Slack/email/DM/paste-into-a-tool.
+
+## Rotation
+
+Rotate **on exposure, on offboarding, and on a schedule** for high-value keys.
+Order: update Bitwarden → redeploy `.env.local` / CI → revoke the old value.
+
+## Sorting an existing repo (the cleanup playbook)
+
+Run this per repo to fix cross-contamination that already exists:
+
+1. **Inventory.** List every secret the repo uses — check `.env.example`,
+   `.env.local`, CI/deploy config, and search history:
+   `git log -p | grep -iE 'key|secret|token|password'` (or use trufflehog / gitleaks).
+2. **Classify** each: **Internal** or **which client**?
+3. **Move** each into the correct Bitwarden collection; **rename** to the
+   convention; **split** any item that mixes owners.
+4. **Fix the repo:** `.env.example` = names only; confirm `.gitignore` covers
+   `.env*`.
+5. **Scan history** for committed secrets. If any are found: **rotate them** and
+   purge from history (BFG / `git filter-repo`).
+6. **Record** deployment targets + scope in each item's notes.
+
+## Per-repo adoption checklist (copy into each repo's PR)
+
+- [ ] `.env.example` lists env-var **names only**, each with a source note
+- [ ] `.gitignore` covers `.env`, `.env.local`, `.env.*.local`
+- [ ] every secret lives in a Bitwarden collection (a client's, or `Hirobius — Internal`)
+- [ ] items named `<Owner> — <System> — <purpose>`; fields labelled with env-var names
+- [ ] no single key shared across owners
+- [ ] git history scanned; any leaked secret rotated + purged
+- [ ] least-privilege scopes confirmed (dedicated read-only users where possible)
+
+## Owner classification — quick reference
+
+| Key type | Owner | Collection | Example |
+|----------|-------|-----------|---------|
+| Your infra / tooling | Hirobius | `Hirobius — Internal` | GitHub PAT, Vercel, domain, CI |
+| A client's systems | That client | `<Client>` | EZLynx, their M365 Graph app, their Gravity keys |
+| Shared vendor you resell | Hirobius (master) + per-client sub-keys | split | one master in Internal, scoped sub-keys per client |
+
+If you can't decide who owns a key, it's Internal until proven client-scoped —
+and if a client ever needs it, mint them their **own** scoped key rather than
+sharing yours.
+
+---
+
+_Canonical copy — edit here, in `hirobius/ops`. Downstream repos link to this file; they do not fork the text._


### PR DESCRIPTION
## What

Makes **`hirobius/ops` the canonical home** for the org-wide **Secrets Management Standard**. The standard was authored in `hirobius/lilac-insure` (the first client fully onto it); this PR moves the authoritative copy here and sets up fleet-wide adoption tracking.

## Changes

- **`standards/secrets-management.md`** — the canonical, repo-agnostic standard. Only the "canonical home" framing was adjusted to point here; all substance is preserved from the Lilac source:
  - Bitwarden Organization; **one collection per client** + a `Hirobius — Internal` collection (collections are the isolation boundary).
  - Every secret has **exactly one owner** (Internal *or* one client, never both).
  - Items named `<Owner> — <System> — <purpose>`; **custom-field labels = the exact env-var name** (1:1 map to `.env.local`).
  - Item types: SSH keys → **SSH Key** item (agent); API keys/tokens/secrets → **Login** item with hidden fields; Secure Notes for unstructured only.
  - Repos hold **env-var NAMES only** (`.env.example`); values live in gitignored `.env.local` or are injected from the secrets manager.
  - **One cloud environment per owner, test creds only** — production client-PII workflows run on client infra, never a shared cloud env.
- **`standards/secrets-adoption.md`** — fleet adoption tracker: `repo | status | owner-classification | history-scanned | tracking issue | notes`, seeded with the active 2026 fleet and a documented exclusion list for legacy (2020–2021 bootcamp) repos. `hirobius/lilac-insure` is marked **compliant** (reference implementation).
- **`README.md`** — links both from the "Where to read" index so the standard is discoverable.

## Safety

No secret **values** anywhere in this PR — env-var **names** only, per the standard itself.

## Follow-up (Task 2, tracked separately)

Per-repo inventory (`.env.example` / `.env*` / CI), a tracking issue per repo ("Adopt secrets standard: &lt;repo&gt;"), the adoption-tracker fill-in, and per-repo remediation PRs (names-only `.env.example`, `.gitignore` coverage, history secret-scan) are in progress and will reference this canonical doc.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts7uVXbLQuZooeg19hZ467)_