### PR TITLE
fix(security): security_invoker on tasks_blocked / tasks_next views

### DIFF
--- a/supabase/migrations/0003_tasks.sql
+++ b/supabase/migrations/0003_tasks.sql
@@ -157,7 +157,7 @@ create trigger tasks_audit_upd after update on tasks
 -- =============================================================================
 -- A task is blocked if ANY dep key is not done. Recomputed LIVE — do not trust
 -- the imported blocked_by snapshot.
-create or replace view tasks_blocked as
+create or replace view tasks_blocked with (security_invoker = on) as
 select t.id, t.key,
        array_remove(array_agg(d.key) filter (where d.status <> 'done'), null) as unmet_deps,
        (count(d.*) filter (where d.status <> 'done')) > 0                     as is_blocked
@@ -167,7 +167,7 @@ where t.deleted_at is null
 group by t.id, t.key;
 
 -- "What's next": open, not deleted, every dep done — the deps-aware daily driver.
-create or replace view tasks_next as
+create or replace view tasks_next with (security_invoker = on) as
 select t.*
 from tasks t
 join tasks_blocked b on b.key = t.key

--- a/supabase/migrations/0009_view_security_invoker.sql
+++ b/supabase/migrations/0009_view_security_invoker.sql
@@ -1,0 +1,20 @@
+-- Migration 0009 — close the SECURITY DEFINER view hole on the tasks views.
+--
+-- Supabase Advisor (2026-07-08) flagged `public.tasks_blocked` and
+-- `public.tasks_next` as CRITICAL "Security Definer View": both were created in
+-- 0003 without `security_invoker`, so by Postgres default they run with the
+-- VIEW OWNER's rights and therefore **bypass the row-level security** that 0003
+-- enables on the underlying `tasks` table. A caller holding the public anon key
+-- could read tasks through these views despite RLS.
+--
+-- Fix: flip both views to `security_invoker = on` (Postgres 15+, which Supabase
+-- runs), so a query through the view is evaluated with the CALLER's rights and
+-- RLS applies. The ops app is unaffected — it reads via the server-side
+-- service-role key, which bypasses RLS either way; this only denies the
+-- anon/authenticated roles the RLS was always meant to deny.
+--
+-- Idempotent; safe to re-run. (0003's CREATE statements are also updated to bake
+-- this in for fresh installs.)
+
+alter view public.tasks_blocked set (security_invoker = on);
+alter view public.tasks_next    set (security_invoker = on);


### PR DESCRIPTION
Closes the two CRITICAL "Security Definer View" findings from the Supabase Advisor. `0003` enables RLS on `tasks`, but `tasks_blocked` / `tasks_next` were created without `security_invoker`, so they ran with the owner's rights and **bypassed that RLS** — a caller with the public anon key could read tasks through the views.

- **`0009_view_security_invoker.sql`** — `alter view … set (security_invoker = on)` for both (fixes the live DB; Adrian runs it in the SQL editor).
- **`0003`** — bakes `with (security_invoker = on)` into the `create view` statements so fresh installs are correct.

**No app impact** — `/ops` reads via the server-side service-role key, which bypasses RLS regardless; this only denies `anon`/`authenticated` as RLS always intended. Freeze-allowed (security hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ts7uVXbLQuZooeg19hZ467

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts7uVXbLQuZooeg19hZ467)_