### PR TITLE
ci(comb): widen tool permissions so the unattended combing agent can act

### DIFF
--- a/.github/workflows/comb-tasks.yml
+++ b/.github/workflows/comb-tasks.yml
@@ -35,6 +35,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Widen tool permissions so the UNATTENDED agent can actually do its
+          # work — query Supabase (node) and use gh to comment/label/file issues.
+          # Last run was blocked because default perms deny Bash without a human
+          # to approve. Broad Bash is acceptable here: ephemeral CI sandbox,
+          # manual-only (workflow_dispatch) job, scoped creds → blast radius is
+          # the tasks board + issues, which is exactly this job's purpose.
+          claude_args: |
+            --allowedTools "Bash,Read,Write,Edit,Glob,Grep"
           prompt: |
             Execute the tasks-board combing job specified in issue #57 of this repo
             (hirobius/ops) — read that issue first for the full spec and constraints.


### PR DESCRIPTION
Unblocks the "Comb tasks board" job (ops#57). Last run was blocked because `claude-code-action`'s default permissions deny `Bash(node:*)`/`Bash(gh:*)` in an unattended run (no human to approve), so the agent couldn't query Supabase or use `gh` to comment/label/file.

Adds `claude_args: --allowedTools "Bash,Read,Write,Edit,Glob,Grep"`. Broad Bash is acceptable for this **ephemeral, manual-only (`workflow_dispatch`)** job with scoped Supabase + GitHub creds — blast radius is the tasks board + issues, which is the job's whole purpose.

Must be on `main` for the workflow to pick it up, hence merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ts7uVXbLQuZooeg19hZ467

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts7uVXbLQuZooeg19hZ467)_