### PR TITLE
chore(ralph): autonomous Ralph loop scaffolding

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,6 @@ node_modules/
 
 # Vendor
 src/lib/vendor/**
+
+# Ralph loop scaffolding — spec-owned, kept byte-exact as authored
+ralph/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,15 @@ Quality gates are registered in `docs/guardrails/registry.json`
 - Update this file and [CLAUDE.md](./CLAUDE.md) only with stable, repo-wide rules.
 - Do not reference missing docs, folders, or workflows as if they exist.
 - When the repo structure changes, update this file to match reality rather than preserving aspirational architecture.
+
+## Ralph quality bar
+
+REPO_TYPE: production
+QUALITY BAR: Private client automation (Lilac/EZLynx). Correctness over speed. No destructive ops.
+
+Rules for any autonomous loop in this repo:
+
+- One issue per PR. Small steps. Never push to main.
+- The gate (ralph/gate.sh) must pass before any PR. No exceptions.
+- Fight entropy: leave the code better than you found it.
+- No shortcut that creates debt someone else pays for.

--- a/ralph/gate.sh
+++ b/ralph/gate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Feedback gate Ralph must pass before opening a PR. Red = no PR.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Repos WITH the loop system:
+# GATE="pnpm loop:validate"
+# ops: the standard trio (all three scripts exist). Correctness over speed —
+# `pnpm check:full` is available if a stricter gate is ever wanted.
+GATE="pnpm typecheck && pnpm test && pnpm lint"
+
+eval "$GATE"

--- a/ralph/loop.sh
+++ b/ralph/loop.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+[ -z "${1:-}" ] && { echo "Usage: $0 <iterations>"; exit 1; }
+touch progress.txt
+
+for ((i=1; i<=$1; i++)); do
+  echo "── Ralph $i/$1 ──"
+  result=$(claude --permission-mode acceptEdits -p "@ralph/prompt.md @AGENTS.md @progress.txt
+
+Do ONE iteration only. If no ralph-ready issues remain, output <promise>COMPLETE</promise>.")
+  echo "$result"
+  [[ "$result" == *"<promise>COMPLETE</promise>"* ]] && { echo "Done after $i."; exit 0; }
+done
+echo "Hit cap ($1)."

--- a/ralph/prompt.md
+++ b/ralph/prompt.md
@@ -1,0 +1,38 @@
+# Ralph loop — one iteration
+
+Read AGENTS.md first. Its "Ralph quality bar" section is binding.
+
+## 1. Pick ONE task
+Run: gh issue list --label "ralph-ready" --state open
+Choose the HIGHEST-PRIORITY issue, not the first. Order:
+1. Architecture / core abstractions
+2. Integration points between modules
+3. Unknowns / spikes
+4. Standard features
+5. Polish, cleanup, quick wins
+If none exist, stop and say so.
+
+## 2. Implement it — small
+- One logical change. If the issue is big, ship the smallest complete
+  slice and comment the rest back on the issue.
+- Follow existing repo patterns. The codebase is the source of truth,
+  not your assumptions.
+
+## 3. Pass the gate — required
+Run: bash ralph/gate.sh
+Must pass with zero errors. If it fails, fix YOUR change until it passes.
+Never open a PR on a red gate. Never weaken tests or types to pass it.
+
+## 4. Record progress
+Append to progress.txt (terse, grammar optional):
+- Issue # + one line
+- Decisions + why
+- Files changed
+- Notes for next iteration
+
+## 5. Ship it
+- Branch: ralph/issue-<n>-<slug>
+- Commit (match this repo's commit style)
+- Open PR with "Closes #<n>" in the body
+- Comment the issue with a 2-line summary
+- Never merge. Never push to main. A human reviews.

--- a/ralph/run.sh
+++ b/ralph/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+touch progress.txt
+
+claude --permission-mode acceptEdits "@ralph/prompt.md @AGENTS.md @progress.txt
+
+Do ONE iteration only, then stop."


### PR DESCRIPTION
## Linked unit

Unit: `N/A` — tooling/setup PR. Stands up the autonomous "Ralph" loop harness so `ralph-ready`-labelled issues can be burned down one-per-PR. Not driven by an orchestration unit.

## Summary

Adds the `ralph/` loop scaffolding and an `AGENTS.md` quality bar so an autonomous agent can pick a single `ralph-ready` issue, make one small change, pass the feedback gate, and open a reviewable PR — never merging, never pushing `main`. Scaffolding only; the scripts are **not** run, and **no issue is tagged `ralph-ready`** — this repo is under a feature freeze, so the loop stays idle until a specific issue is greenlit.

- `ralph/prompt.md` — one-iteration loop prompt (pick ONE highest-priority `ralph-ready` issue → small change → `bash ralph/gate.sh` → record `progress.txt` → PR `Closes #<n>`; never merge/push main).
- `ralph/gate.sh` — pre-PR feedback gate: `pnpm typecheck && pnpm test && pnpm lint` (all three scripts exist here; `pnpm check:full` is available if a stricter gate is ever wanted).
- `ralph/run.sh` / `ralph/loop.sh` — single-shot (HITL) and N-iteration (AFK) drivers.
- `AGENTS.md` — **Ralph quality bar** appended: `REPO_TYPE: production`; "Private client automation (Lilac/EZLynx). Correctness over speed. No destructive ops."
- `.prettierignore` — exempts `ralph/` so the spec-owned prompt/scripts stay byte-exact.

## Validator output

Change touches only `ralph/`, `AGENTS.md`, `.prettierignore` — no source, schema, manifest, or orchestration. `AGENTS.md` was pre-formatted with Prettier; `ralph/` is Prettier-exempt. Commit passed the pre-commit hook with no `--no-verify`.

```
Scope: docs + scaffolding only. No typecheck/manifest/orchestration surface touched.
```

## Breaking change

- [ ] This PR introduces a breaking change to a public API surface.

N/A — no API, schema, or validator change.

## Screenshots (if visual)

- [x] N/A — this PR is non-visual.

## Checklist

- [x] Commit message follows the `<scope>(<area>): <summary>` format with the `Co-Authored-By` trailer.
- [x] No orchestration unit is involved (scaffolding PR) — nothing to update.
- [x] No `--no-verify` was used to bypass gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013XnHjXgDMfKqSUpQXVp6nc)_