### PR TITLE
fix(ralph): keep the selector's stdout pure — parking leaked URLs into the pick

### DIFF
--- a/.github/workflows/ralph-run-reusable.yml
+++ b/.github/workflows/ralph-run-reusable.yml
@@ -118,6 +118,10 @@ jobs:
             echo "::error::ralph/next.sh failed (code $code) — GitHub API trouble, not an empty queue."
             exit 1
           fi
+          if ! [[ "$issue" =~ ^[0-9]+$ ]]; then
+            echo "::error::selector emitted non-numeric output ('$issue') — a helper leaked stdout; refusing to claim garbage."
+            exit 1
+          fi
           # Atomic claim (ref create = test-and-set): losing means another
           # runner (local or CI) owns it — skip, never double-work.
           if ! claim_issue "$issue" "$RUN_ID"; then

--- a/ralph/lib.sh
+++ b/ralph/lib.sh
@@ -215,9 +215,12 @@ park_issue() {
   fi
   ensure_label ralph-parked D93F0B "Parked by the Ralph loop — see the park comment"
   ensure_label needs-adrian 5319E7 "Blocked on a human decision"
-  gh_retry issue edit "$n" --remove-label "$RALPH_READY_LABEL" --add-label "$label" || true
+  # >/dev/null matters: gh edit/comment print URLs on stdout, and park_issue
+  # runs inside next.sh's candidate walk — stray stdout would corrupt the
+  # selected-issue capture in run.sh / the CI guard (bit us on the first run).
+  gh_retry issue edit "$n" --remove-label "$RALPH_READY_LABEL" --add-label "$label" >/dev/null || true
   gh_retry issue comment "$n" --body "🅿️ **Ralph parked this issue** — $reason
-(To retry: fix the cause, then re-add \`$RALPH_READY_LABEL\`.)" || true
+(To retry: fix the cause, then re-add \`$RALPH_READY_LABEL\`.)" >/dev/null || true
 }
 
 # ---------------------------------------------------------------- reconcile

--- a/ralph/next.sh
+++ b/ralph/next.sh
@@ -48,14 +48,16 @@ for n in $ordered; do
   body=$(jq -r --argjson n "$n" '.[] | select(.number == $n) | .body // ""' <<<"$issues")
   if ! has_dod_marker "$body"; then
     echo "ralph: #$n has no acceptance-criteria/DoD marker — parking" >&2
-    park_issue "$n" "no acceptance criteria found in the body (looked for a \`- [ ]\` checklist or an acceptance / DoD / definition-of-done section). Add one, then re-add \`$RALPH_READY_LABEL\`." needs-adrian
+    # >&2: this script's stdout is ONLY the selected issue number; park side
+    # effects must never leak into it (callers capture it).
+    park_issue "$n" "no acceptance criteria found in the body (looked for a \`- [ ]\` checklist or an acceptance / DoD / definition-of-done section). Add one, then re-add \`$RALPH_READY_LABEL\`." needs-adrian >&2
     continue
   fi
 
   fails=$(count_failed_attempts "$n")
   if [ "${fails:-0}" -ge "$RALPH_MAX_ATTEMPTS" ]; then
     echo "ralph: #$n already failed $fails attempt(s) — parking" >&2
-    park_issue "$n" "hit the attempt cap ($fails/$RALPH_MAX_ATTEMPTS failed attempts — see the ralph-attempt-failed comments above)." ralph-parked
+    park_issue "$n" "hit the attempt cap ($fails/$RALPH_MAX_ATTEMPTS failed attempts — see the ralph-attempt-failed comments above)." ralph-parked >&2
     continue
   fi
 

--- a/ralph/run.sh
+++ b/ralph/run.sh
@@ -115,6 +115,12 @@ races=0
 while :; do
   sel=0
   ISSUE=$(bash ralph/next.sh) || sel=$? # ||-guarded: exit 10/20 must not trip the ERR trap
+  if [ "$sel" -eq 0 ] && ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+    # selector stdout must be exactly one issue number — anything else means
+    # a helper leaked output; fail loud rather than claim garbage
+    echo "ralph: selector emitted non-numeric output: '$ISSUE'" >&2
+    sel=20
+  fi
   case $sel in
   0) ;;
   10)


### PR DESCRIPTION
## Linked unit

N/A — live-fire follow-up to #116, caught on the chain's first post-merge run.

## Summary

Run [29132300389](https://github.com/hirobius/ops/actions/runs/29132300389) (first run of the new engine) exposed a stdout-purity bug: `gh issue edit`/`gh issue comment` print URLs to stdout, so when `ralph/next.sh` parked DoD-less candidates mid-selection (#3, #13, #39 — the *parking* was correct), those URLs corrupted the captured issue number. The claim failed on a garbage ref name and the run skipped quietly — CI would never claim work again.

Fix: `park_issue`'s gh calls are `>/dev/null`'d, `next.sh` routes park output to stderr, and both consumers (`run.sh` + the CI guard) now validate the capture is exactly one number — any future leak fails **loud** (exit 20 / red run) instead of silently skipping.

## Validator output

```
$ bash -n ralph/*.sh                          → OK
$ next.sh via URL-printing gh shim (non-dry)  → stdout is exactly "112"
$ run.sh fed a garbage selector               → exit 20, names the bad output
```

## Breaking change

- [ ] None — behavior fix within the #116 contract.

## Screenshots (if visual)

- [x] N/A — non-visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT

---
_Generated by [Claude Code](https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT)_