### PR TITLE
fix(ralph): gh --jq has no --arg flag — claim re-verify rejected every claim

### DIFF
--- a/.github/workflows/ralph-gate-reusable.yml
+++ b/.github/workflows/ralph-gate-reusable.yml
@@ -256,13 +256,14 @@ jobs:
           if [ "$v" = "approve" ]; then
             gh api "repos/${{ github.repository }}/statuses/$SHA" \
               -f state=success -f context=ralph-gate -f description="gate green + AI approved" >/dev/null
-            pr_ok=$(gh pr view "$PR" --json labels \
-              --jq --arg l "$RALPH_APPROVE_LABEL" '[.labels[].name] | index($l) != null')
+            # Pipe to real jq — gh's --jq has no --arg flag (see ralph/lib.sh).
+            pr_ok=$(gh pr view "$PR" --json labels |
+              jq -r --arg l "$RALPH_APPROVE_LABEL" '[.labels[].name] | index($l) != null')
             issue_ok=false
             n=$(gh pr view "$PR" --json body --jq .body | grep -oiE 'closes #[0-9]+' | head -n1 | grep -oE '[0-9]+' || true)
             if [ -n "$n" ]; then
-              issue_ok=$(gh issue view "$n" --json labels \
-                --jq --arg l "$RALPH_AUTO_MERGE_LABEL" '[.labels[].name] | index($l) != null' 2>/dev/null || echo false)
+              issue_ok=$(gh issue view "$n" --json labels 2>/dev/null |
+                jq -r --arg l "$RALPH_AUTO_MERGE_LABEL" '[.labels[].name] | index($l) != null' || echo false)
             fi
             if [ "$pr_ok" = "true" ] || [ "$issue_ok" = "true" ]; then
               why="\`$RALPH_APPROVE_LABEL\` label"

--- a/ralph/lib.sh
+++ b/ralph/lib.sh
@@ -172,10 +172,12 @@ claim_issue() {
   gh issue comment "$n" --body "ralph-claim $run_id" >/dev/null 2>&1 || true
   # The claim only counts if the issue is still open and still queued —
   # otherwise it was closed/retracted between select and claim.
-  ok=$(gh issue view "$n" --json state,labels \
-    --jq --arg l "$RALPH_READY_LABEL" \
-    'if .state == "OPEN" and ([.labels[].name] | index($l) != null) then "yes" else "no" end' \
-    2>/dev/null || echo no)
+  # Pipe to real jq: gh's --jq takes only an expression, it has NO --arg flag
+  # (using one makes gh error and every re-verify silently fail — bit us live).
+  ok=$(gh issue view "$n" --json state,labels 2>/dev/null |
+    jq -r --arg l "$RALPH_READY_LABEL" \
+      'if .state == "OPEN" and ([.labels[].name] | index($l) != null) then "yes" else "no" end' \
+      2>/dev/null || echo no)
   if [ "$ok" != "yes" ]; then
     echo "ralph: #$n was closed or unqueued between select and claim — releasing" >&2
     release_claim "$n"


### PR DESCRIPTION
## Linked unit

N/A — second live-fire follow-up to #116/#117, caught on chain run [29132512863](https://github.com/hirobius/ops/actions/runs/29132512863).

## Summary

The #117 fix worked (clean numeric capture of #44, claim ref created) — but the post-claim re-verify used `gh issue view --jq --arg …`. `gh`'s `--jq` takes only an expression; there is no `--arg` flag, so gh errored, the error was swallowed, and **every claim was released** as "closed or unqueued" — CI could claim nothing. The same misuse sat latent in ralph-gate's merge-policy step (the `ralph-approved`/`ralph-auto` label checks), which would have broken the approval path on the first real Ralph PR. Both spots now pipe gh's JSON output to real `jq -r --arg`.

## Validator output

```
$ bash -n ralph/*.sh + YAML parse                        → OK
$ full non-dry claim path vs an --arg-rejecting gh shim  → CLAIM OK
$ selector purity + rerun determinism                    → picks '112' '112'
```

## Breaking change

- [ ] None.

## Screenshots (if visual)

- [x] N/A — non-visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT

---
_Generated by [Claude Code](https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT)_