### PR TITLE
fix(ralph): chain push runs re-enter via workflow_dispatch — the action rejects push events

### DIFF
--- a/.github/workflows/ralph-run-reusable.yml
+++ b/.github/workflows/ralph-run-reusable.yml
@@ -40,6 +40,7 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
+      actions: write # chain hop: push runs re-dispatch themselves (see below)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -132,6 +133,25 @@ jobs:
           echo "Claimed #$issue (run $RUN_ID)."
           echo "issue=$issue" >> "$GITHUB_OUTPUT"
 
+      - name: Chain hop — a push run re-enters via workflow_dispatch
+        id: chain
+        if: steps.guard.outputs.issue != '' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # claude-code-action@v1 hard-rejects `push` events ("Unsupported
+          # event type: push") — a latent flaw in the original chain that the
+          # working guard exposed on its first claimed push run. So the chain
+          # converts the push into an explicit dispatch of the issue we just
+          # claimed; the dispatched run's claim-steal re-claims it and runs
+          # the model under a supported event. No loop risk: dispatch runs
+          # never re-dispatch (this step is push-only), and the concurrency
+          # group keeps the hop serialized.
+          gh workflow run "${{ github.workflow }}" -R "$GITHUB_REPOSITORY" \
+            --field issue="${{ steps.guard.outputs.issue }}"
+          echo "Chained: dispatched '${{ github.workflow }}' for issue #${{ steps.guard.outputs.issue }}."
+          echo "chained=true" >> "$GITHUB_OUTPUT"
+
       - name: Alert Discord — Ralph loop wedged behind a stuck PR
         if: steps.guard.outputs.wedged == 'true'
         env:
@@ -153,21 +173,21 @@ jobs:
             "$DISCORD_WEBHOOK_URL" || echo "Discord alert failed (non-fatal)."
 
       - uses: pnpm/action-setup@v4
-        if: steps.guard.outputs.issue != ''
+        if: steps.guard.outputs.issue != '' && steps.chain.outputs.chained != 'true'
         with:
           version: "10"
       - uses: actions/setup-node@v4
-        if: steps.guard.outputs.issue != ''
+        if: steps.guard.outputs.issue != '' && steps.chain.outputs.chained != 'true'
         with:
           node-version: "22"
           cache: "pnpm"
       - name: Install dependencies (so ralph/gate.sh can run)
-        if: steps.guard.outputs.issue != ''
+        if: steps.guard.outputs.issue != '' && steps.chain.outputs.chained != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run Claude Code — one Ralph iteration on the claimed issue
         id: work
-        if: steps.guard.outputs.issue != ''
+        if: steps.guard.outputs.issue != '' && steps.chain.outputs.chained != 'true'
         continue-on-error: true # reconcile decides the real outcome
         uses: anthropics/claude-code-action@v1
         with:
@@ -195,7 +215,7 @@ jobs:
             - If blocked or ambiguous, comment on the issue and STOP.
 
       - name: Reconcile — state decides what actually happened
-        if: always() && steps.guard.outputs.issue != ''
+        if: always() && steps.guard.outputs.issue != '' && steps.chain.outputs.chained != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -39,6 +39,7 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
+      actions: write # chain hop: push runs re-dispatch as workflow_dispatch
     with:
       issue: ${{ inputs.issue || '' }}
     secrets: inherit


### PR DESCRIPTION
## Linked unit

N/A — third live-fire follow-up (#116 → #117 → #118), caught on chain run [29133760732](https://github.com/hirobius/ops/actions/runs/29133760732).

## Summary

The hardened pipeline finally got a push run through claim (#44 claimed cleanly; reconcile recorded attempt 1/2, released the claim, failed loud + Discord-pinged — all as designed), which exposed a **latent flaw in the original chain design**: `claude-code-action@v1` hard-rejects `push` events ("Unsupported event type: push"). The push-to-main chain trigger could never have run an iteration; it was invisible before because the old guard always skipped push runs.

Fix: a push run now claims, re-dispatches its own workflow with the claimed issue (`gh workflow run … --field issue=N`, needs `actions: write`), and stops; the dispatched run steals/re-claims and works the issue under `workflow_dispatch` — a supported event. No loop risk (the hop is push-only; dispatch runs never re-dispatch) and the existing concurrency group serializes it.

## Validator output

```
$ YAML parse both workflows + bash -n every run: block → OK
```

## Breaking change

- [ ] None — callers gain `actions: write` (included for ops' caller here; consumer-repo callers copy it per ralph/README.md).

## Screenshots (if visual)

- [x] N/A — non-visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT

---
_Generated by [Claude Code](https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT)_