### PR TITLE
fix(ralph): allow bot actors on the run workflow's model step

### DIFF
--- a/.github/workflows/ralph-run-reusable.yml
+++ b/.github/workflows/ralph-run-reusable.yml
@@ -192,6 +192,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The chain hop dispatches as github-actions[bot], and the action
+          # rejects bot actors by default — same setting ralph-gate always had.
+          allowed_bots: "*"
           claude_args: |
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep"
           prompt: |


### PR DESCRIPTION
## Linked unit

N/A — fourth live-fire follow-up (#116 → #117 → #118 → #119), caught on chain run [29134767635](https://github.com/hirobius/ops/actions/runs/29134767635).

## Summary

The #119 chain hop worked (push run claimed #44 and dispatched; the dispatched run re-claimed and reached the model step) — but `claude-code-action` rejects non-human actors by default, and the hop's dispatcher is `github-actions[bot]`: `"Workflow initiated by non-human actor"`. ralph-gate has carried `allowed_bots: "*"` since its original design; the run engine's model step now matches.

Note: reconcile correctly parked #44 at the attempt cap (2/2) during these two harness failures — designed behavior, honest audit trail. Since both failures were infrastructure (not the issue's work), #44 will be re-queued (attempt comments cleared, `ralph-ready` re-added) once this lands, which also live-tests the `issues: labeled` trigger path.

## Validator output

```
$ YAML parse → OK (one-line input addition, mirrors ralph-gate's existing setting)
```

## Breaking change

- [ ] None.

## Screenshots (if visual)

- [x] N/A — non-visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT

---
_Generated by [Claude Code](https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT)_