### PR TITLE
chore: pin packageManager pnpm@10.33.0 for the Ralph engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "pnpm": ">=8"
   },
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "module": "./dist/hirobius-ui.js",
   "types": "./src/index.ts",
   "sideEffects": [


### PR DESCRIPTION
## Summary

The engine no longer hardcodes a pnpm version (hirobius/ralph#1 — `pnpm/action-setup` errors when both the action config and `packageManager` specify one, which broke the first hds/site-engine chain runs). `pnpm/action-setup` now reads the version from this field, which hds and site-engine already pin. Matches the lockfile's pnpm 10.33.0.

## Validator output

```
$ node -e "require('./package.json')" → valid; packageManager === pnpm@10.33.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT

---
_Generated by [Claude Code](https://claude.ai/code/session_014PjwXJeTKHfWaU1e2p24TT)_