### PR TITLE
fix(ci): pin Ralph engine callers to known-good sha — outage mitigation (#144)

### DIFF
--- a/.github/workflows/ralph-gate.yml
+++ b/.github/workflows/ralph-gate.yml
@@ -16,7 +16,10 @@ on:
 
 jobs:
   ralph-gate:
-    uses: hirobius/ralph/.github/workflows/ralph-gate-reusable.yml@main
+    # TEMP outage pin (ops#144): hirobius/ralph@main regressed at 7387f7c8 —
+    # every @main gate call startup-fails. Pinned to the last known-good
+    # engine sha; restore @main once the engine is fixed.
+    uses: hirobius/ralph/.github/workflows/ralph-gate-reusable.yml@03dea1df3554eb34ec5e7b7231488c6bfe9ac7bb
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -34,7 +34,9 @@ concurrency:
 
 jobs:
   ralph:
-    uses: hirobius/ralph/.github/workflows/ralph-run-reusable.yml@main
+    # TEMP outage pin (ops#144): same known-good engine sha as ralph-gate.yml —
+    # the run reusable was touched by the same sweep. Restore @main once fixed.
+    uses: hirobius/ralph/.github/workflows/ralph-run-reusable.yml@03dea1df3554eb34ec5e7b7231488c6bfe9ac7bb
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Linked unit

Unit: n/a (orchestration retired) — this is the mitigation for outage **#144**.

## Summary

`hirobius/ralph@main` regressed at `7387f7c8` (~07:50 UTC): every reusable-workflow call org-wide dies in `startup_failure`, freezing both the gate (no Ralph PR can merge — #133 is stuck with `ralph-approved` armed) and the loop itself. The engine repo couldn't be attached to this session (approval channel wedged), so this pins ops's two thin callers to `03dea1df` — the engine sha behind the last fully-green gate run — with clearly-marked TEMP comments. **This PR's own `ralph-gate` check running green is the end-to-end proof of the fix** (pull_request gates execute the merge-ref workflow, which resolves the pinned reusable).

Follow-up (tracked on #144): fix or revert the engine repo itself, restore `@main` in these two files, and apply the same one-line pin to hds/site-engine if they need un-freezing before then.

## Validator output

No app code touched — two `uses:` lines + comments in `.github/workflows/{ralph-gate,ralph}.yml`. The meaningful validator is this PR's own ralph-gate check: startup_failure before the pin, running job after it.

## Breaking change

- [ ] Breaking change — no. Reversible two-line pin.

## Screenshots (if visual)

- [x] N/A — this PR is non-visual.

## Checklist

- [x] `Co-Authored-By` trailer present
- [ ] Orchestration entry — n/a, retired
- [ ] `--no-verify` — used, per the documented sandbox wart (editorconfig-checker binary 403s); no gates are relevant to a 2-line YAML pin beyond the live check this PR exercises

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE)_