### PR TITLE
fix(ci): restore Ralph engine callers to @main — #144 was caller skew, not an engine regression

### DIFF
--- a/.github/workflows/ralph-gate.yml
+++ b/.github/workflows/ralph-gate.yml
@@ -16,10 +16,7 @@ on:
 
 jobs:
   ralph-gate:
-    # TEMP outage pin (ops#144): hirobius/ralph@main regressed at 7387f7c8 —
-    # every @main gate call startup-fails. Pinned to the last known-good
-    # engine sha; restore @main once the engine is fixed.
-    uses: hirobius/ralph/.github/workflows/ralph-gate-reusable.yml@03dea1df3554eb34ec5e7b7231488c6bfe9ac7bb
+    uses: hirobius/ralph/.github/workflows/ralph-gate-reusable.yml@main
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -34,9 +34,7 @@ concurrency:
 
 jobs:
   ralph:
-    # TEMP outage pin (ops#144): same known-good engine sha as ralph-gate.yml —
-    # the run reusable was touched by the same sweep. Restore @main once fixed.
-    uses: hirobius/ralph/.github/workflows/ralph-run-reusable.yml@03dea1df3554eb34ec5e7b7231488c6bfe9ac7bb
+    uses: hirobius/ralph/.github/workflows/ralph-run-reusable.yml@main
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Linked unit

Unit: n/a (orchestration retired) — resolves outage issue **#144**. Closes #144.

## Summary

Reverts the #146 sha-pin now that the real root cause is proven: engine commit `7387f7c8` (chain hop after `GITHUB_TOKEN` auto-merges) requires callers to grant `actions: write`; Ralph PR branches vendored **before ops#132** didn't grant it, and a reusable workflow can't exceed its caller's permissions — so validation failed with `startup_failure`/zero jobs on exactly those PRs, while every fresh branch passed (PR #145's gate ran green on the "broken" sha). Fixed PR #133 by updating its branch from main; it auto-merged at 16:04 and #127 closed.

Keeping the pin would be actively harmful: `03dea1df` predates the chain hop, so gate-token merges under the pin never wake the next loop iteration.

This PR's own green `ralph-gate` check is the proof `@main` is safe again for ops.

## Validator output

Two `uses:` lines restored + TEMP comments removed. Pre-push hook ran full `pnpm typecheck` against DS 0.13 locally — clean. The live check on this PR is the meaningful gate.

## Breaking change

- [ ] No.

## Screenshots (if visual)

- [x] N/A — non-visual.

## Checklist

- [x] `Co-Authored-By` trailer present
- [ ] Orchestration — n/a, retired
- [x] No `--no-verify` on the push (hooks ran and passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE)_