### PR TITLE
chore(hooks): move editorconfig-checker out of pre-commit — CI covers it (#39)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -24,9 +24,6 @@ node scripts/validate-guardrail-registry.mjs
 echo "Checking lockfile integrity (pnpm install --frozen-lockfile)..."
 pnpm install --frozen-lockfile --offline --prefer-offline --ignore-scripts --silent 2>/dev/null || (echo "Lockfile drift detected: run 'pnpm install' to resync pnpm-lock.yaml" && exit 1)
 
-echo "Checking file encoding (editorconfig-checker — charset utf-8 enforcement)..."
-pnpm exec editorconfig-checker
-
 echo "Running all pre-commit registry gates (15 gates, declaration order)..."
 # Single source of truth: reads docs/guardrails/registry.json --channel pre-commit.
 # Gate list and order are authoritative from the registry — never edit gate

--- a/docs/guardrails/registry.json
+++ b/docs/guardrails/registry.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
   "generated": "2026-05-05T00:00:00.000Z",
-  "precommitStructureHash": "79c0ba29fc869e2883956bf87a19fd4ea8bc967547eaf27aa3dacb6ea2469a2a",
-  "precommitStructureHashUpdatedAt": "2026-07-07T18:01:41.652Z",
+  "precommitStructureHash": "f3f5e12b4813af8d6719dca2d18a4ff7d9d12cfa604cea52c2c0e5d9462665b2",
+  "precommitStructureHashUpdatedAt": "2026-07-11T16:59:33.379Z",
   "gates": [
     {
       "id": "audit-soft-gates",
@@ -18,7 +18,7 @@
     },
     {
       "id": "audit-batch-deliverables",
-      "description": "TODO: add description \u2014 audit-batch-deliverables.mjs JSDoc block is empty.",
+      "description": "TODO: add description — audit-batch-deliverables.mjs JSDoc block is empty.",
       "severity": "warn",
       "gateScript": "scripts/audit-batch-deliverables.mjs",
       "fixturePath": "fixtures/audit-batch-deliverables",
@@ -30,7 +30,7 @@
     },
     {
       "id": "audit-bundle",
-      "description": "Generates a bundle composition report at docs/perf/bundle-report.html using vite-bundle-visualizer. Manual channel only \u2014 artifact, not gating.",
+      "description": "Generates a bundle composition report at docs/perf/bundle-report.html using vite-bundle-visualizer. Manual channel only — artifact, not gating.",
       "severity": "warn",
       "gateScript": "scripts/audit-bundle.mjs",
       "fixturePath": null,
@@ -68,7 +68,7 @@
     },
     {
       "id": "audit-exceptions",
-      "description": "TODO: add description \u2014 audit-exceptions.mjs has no leading JSDoc block.",
+      "description": "TODO: add description — audit-exceptions.mjs has no leading JSDoc block.",
       "severity": "warn",
       "gateScript": "scripts/audit-exceptions.mjs",
       "fixturePath": "fixtures/audit-exceptions",
@@ -107,7 +107,7 @@
     },
     {
       "id": "audit-pages",
-      "description": "Token compliance auditor for page surfaces. This is intentionally looser than audit-components.mjs \u2014 reusable components must be strict, pages must still avoid raw design values but can keep justified editorial layout.",
+      "description": "Token compliance auditor for page surfaces. This is intentionally looser than audit-components.mjs — reusable components must be strict, pages must still avoid raw design values but can keep justified editorial layout.",
       "severity": "warn",
       "gateScript": "scripts/audit-pages.mjs",
       "fixturePath": "fixtures/audit-pages",
@@ -119,7 +119,7 @@
     },
     {
       "id": "audit-sbom",
-      "description": "Generates a CycloneDX Software Bill of Materials at docs/security/sbom.json. Manual channel \u2014 produces an artifact, not a gate. Useful for the GRC narrative and supply-chain review.",
+      "description": "Generates a CycloneDX Software Bill of Materials at docs/security/sbom.json. Manual channel — produces an artifact, not a gate. Useful for the GRC narrative and supply-chain review.",
       "severity": "warn",
       "gateScript": "scripts/audit-sbom.mjs",
       "fixturePath": null,
@@ -153,7 +153,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-attributions",
@@ -166,7 +166,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-code-connect",
@@ -179,7 +179,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-contrast",
@@ -192,7 +192,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-doc-structure",
@@ -205,7 +205,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-link-integrity",
@@ -269,7 +269,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-frozen-demos",
@@ -282,7 +282,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-hardcoded-colors",
@@ -314,7 +314,7 @@
     },
     {
       "id": "check-motion",
-      "description": "Verifies that interactive components ship with motion feedback \u2014 the HDS standard that every user action has a visible, token-timed response.",
+      "description": "Verifies that interactive components ship with motion feedback — the HDS standard that every user action has a visible, token-timed response.",
       "severity": "warn",
       "gateScript": "scripts/check-motion.mjs",
       "fixturePath": "fixtures/check-motion",
@@ -323,7 +323,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-og-meta",
@@ -336,7 +336,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "pre-commit",
-      "wiringTodo": "should be ci-pr or ci-scheduled \u2014 not yet wired into a workflow that actually triggers it"
+      "wiringTodo": "should be ci-pr or ci-scheduled — not yet wired into a workflow that actually triggers it"
     },
     {
       "id": "check-page-shell",
@@ -361,7 +361,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-registry",
@@ -374,11 +374,11 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "manual",
-      "retiredFromPreCommit": "DS-authoring gate \u2014 ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
+      "retiredFromPreCommit": "DS-authoring gate — ops consumes the design system, does not author it (2026-07-07). Run via the manual channel on demand."
     },
     {
       "id": "check-route-coverage",
-      "description": "Route coverage gate \u2014 every routable page must appear in the layout-integrity test set.",
+      "description": "Route coverage gate — every routable page must appear in the layout-integrity test set.",
       "severity": "warn",
       "gateScript": "scripts/check-route-coverage.mjs",
       "fixturePath": "fixtures/check-route-coverage",
@@ -399,7 +399,7 @@
       "owner": "Adrian",
       "source": "human",
       "firingChannel": "pnpm-meta",
-      "wiringTodo": "should be ci-pr or ci-scheduled \u2014 not yet wired into a workflow that actually triggers it"
+      "wiringTodo": "should be ci-pr or ci-scheduled — not yet wired into a workflow that actually triggers it"
     },
     {
       "id": "check-secrets",
@@ -453,7 +453,7 @@
     },
     {
       "id": "check-validator-wiring",
-      "description": "Meta-validator: every gate registered in docs/guardrails/registry.json has a firingChannel that matches actual invocation. Catches aspirational guardrails \u2014 gates registered but never really firing.",
+      "description": "Meta-validator: every gate registered in docs/guardrails/registry.json has a firingChannel that matches actual invocation. Catches aspirational guardrails — gates registered but never really firing.",
       "severity": "warn",
       "gateScript": "scripts/check-validator-wiring.mjs",
       "fixturePath": "fixtures/check-validator-wiring",
@@ -479,7 +479,7 @@
     },
     {
       "id": "audit-orphan-wip",
-      "description": "Scans every branch ahead of main and classifies each commit as tracked/orphan based on whether it has a 'Refs: <task-id>' line that points to an open Hermes Kanban task. Companion to check-commit-message-task-ref (which catches new orphans pre-commit); this catches the existing backlog. Always exits 0 \u2014 purely informational. Run via 'pnpm audit:wip'. Writes docs/guardrails/orphan-wip-report.json.",
+      "description": "Scans every branch ahead of main and classifies each commit as tracked/orphan based on whether it has a 'Refs: <task-id>' line that points to an open Hermes Kanban task. Companion to check-commit-message-task-ref (which catches new orphans pre-commit); this catches the existing backlog. Always exits 0 — purely informational. Run via 'pnpm audit:wip'. Writes docs/guardrails/orphan-wip-report.json.",
       "severity": "info",
       "gateScript": "scripts/audit-orphan-wip.mjs",
       "fixturePath": "fixtures/audit-orphan-wip",
@@ -492,7 +492,7 @@
     },
     {
       "id": "generate-strength-report",
-      "description": "Pure observer that reads registry.json, orchestration.json, swarm-watchdog-decisions.jsonl, tsconfig.json, and component-api.json. Computes Score A (Internal Integrity, 6 dims) + Score B (Industry Benchmark, 8 dims) per the 13s-strength-1 ADR. Emits docs/guardrails/strength-report.md and strength-report.json. Idempotent (same input \u2192 byte-identical output modulo timestamp). Fast (<2s). No mutations to source files.",
+      "description": "Pure observer that reads registry.json, orchestration.json, swarm-watchdog-decisions.jsonl, tsconfig.json, and component-api.json. Computes Score A (Internal Integrity, 6 dims) + Score B (Industry Benchmark, 8 dims) per the 13s-strength-1 ADR. Emits docs/guardrails/strength-report.md and strength-report.json. Idempotent (same input → byte-identical output modulo timestamp). Fast (<2s). No mutations to source files.",
       "severity": "warn",
       "gateScript": "scripts/generate-strength-report.mjs",
       "fixturePath": "fixtures/generate-strength-report",
@@ -533,7 +533,7 @@
     },
     {
       "id": "audit-gate-replaceability",
-      "description": "Planning artifact: reads registry.json and produces a per-gate replaceability verdict (fully-replaceable / partially-replaceable / genuinely-custom) with industry-tool replacements and migration cost estimates. Output: /tmp/gate-replaceability-audit.json + docs/guardrails/gate-replaceability-plan.md. Manual channel only \u2014 run on demand when evaluating gate rationalization.",
+      "description": "Planning artifact: reads registry.json and produces a per-gate replaceability verdict (fully-replaceable / partially-replaceable / genuinely-custom) with industry-tool replacements and migration cost estimates. Output: /tmp/gate-replaceability-audit.json + docs/guardrails/gate-replaceability-plan.md. Manual channel only — run on demand when evaluating gate rationalization.",
       "severity": "warn",
       "gateScript": "scripts/audit-gate-replaceability.mjs",
       "fixturePath": "fixtures/audit-gate-replaceability",
@@ -546,7 +546,7 @@
     },
     {
       "id": "check-snapshot-staleness",
-      "description": "Warns when a committed snapshot baseline JSON is older than any of its source files \u2014 catching baselines that should have been regenerated after a source change but weren't. Covers fixtures/figma-masters/snapshot-pre-8v3.json (sources: pipeline/figma-masters-batch.mjs + public/hds-manifest.json) and fixtures/doc-pages/snapshot.json (sources: src/app/pages/docs/**/*.tsx). Warn-only by default; set STALENESS_ENFORCE=error to make blocking.",
+      "description": "Warns when a committed snapshot baseline JSON is older than any of its source files — catching baselines that should have been regenerated after a source change but weren't. Covers fixtures/figma-masters/snapshot-pre-8v3.json (sources: pipeline/figma-masters-batch.mjs + public/hds-manifest.json) and fixtures/doc-pages/snapshot.json (sources: src/app/pages/docs/**/*.tsx). Warn-only by default; set STALENESS_ENFORCE=error to make blocking.",
       "severity": "warn",
       "gateScript": "scripts/check-snapshot-staleness.mjs",
       "fixturePath": null,
@@ -559,7 +559,7 @@
     },
     {
       "id": "audit-sites",
-      "description": "Site-quality / redesign-need auditor (#21). Reads custom-site leads from Supabase, calls Google PageSpeed Insights, and scores each site (0-100 inverse). Operator CLI + data tool, not a guardrail \u2014 manual channel, needs PAGESPEED_API_KEY + migration 0006.",
+      "description": "Site-quality / redesign-need auditor (#21). Reads custom-site leads from Supabase, calls Google PageSpeed Insights, and scores each site (0-100 inverse). Operator CLI + data tool, not a guardrail — manual channel, needs PAGESPEED_API_KEY + migration 0006.",
       "severity": "warn",
       "gateScript": "scripts/audit-sites.mjs",
       "fixturePath": null,


### PR DESCRIPTION
## Linked unit

Unit: n/a (orchestration retired) — the last DoD item of **#39**. Closes #39.

## Summary

Ralph's autonomous run verified every other #39 item done, traced this exact fix, and correctly refused to apply it (hook files require interactive human approval — see its blocked-report on the issue). Applied here in an interactive session with Adrian present: the `editorconfig-checker` step leaves `.husky/pre-commit` (its binary download 403s in sandboxed web sessions, forcing `--no-verify` on every web commit; CI's `pnpm check:full` already runs the same check on every push/PR), and `precommitStructureHash` is refreshed via `scripts/update-precommit-hash.mjs` with the registry committed alongside per the script's instruction.

**Proof:** this PR's own commit ran the full pre-commit chain (registry validation, lockfile integrity, all 15 registry gates incl. a fresh-cache `validate-fixture-proof-of-firing`) and pre-push (typecheck + tests) — **no `--no-verify`**. First clean-hooks web-session commit in the repo's history.

## Validator output

```
pre-commit: validate-guardrail-registry ✓ · frozen-lockfile ✓ · 15 registry gates ✓
  (validate-fixture-proof-of-firing: 45 gates accounted for, 9 real, 34 stubs, 0 failures after fresh cache)
pre-push: typecheck ✓ · tests ✓
```

## Breaking change

- [ ] No — local-hook behavior only; CI unchanged.

## Screenshots (if visual)

- [x] N/A — non-visual.

## Checklist

- [x] `Co-Authored-By` trailer present
- [ ] Orchestration — n/a, retired
- [x] No `--no-verify` was used — the point of the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE)_