### PR TITLE
fix(github): parseIssueRef accepts /pull/N — completes the loop's Approve-merge action (#137)

### DIFF
--- a/api/task-action.ts
+++ b/api/task-action.ts
@@ -7,7 +7,7 @@
  * Request:  { key: string, action: Action, actor?: string }
  *   Action = 'done' | 'reopen' | 'claim' | 'unclaim' | 'trash' | 'restore' | 'dispatch'
  *          | 'auto_on' | 'auto_off' | 'queue' | 'unqueue'
- *          | 'ralph_ready_on' | 'ralph_ready_off'
+ *          | 'ralph_ready_on' | 'ralph_ready_off' | 'ralph_approve'
  *
  * 'auto_on' / 'auto_off' flip `auto_ok` (migration 0008) — the Fleet
  * auto-dispatch opt-in (epic #41). Slice 2's dispatcher only picks up rows
@@ -29,6 +29,12 @@
  * Ralph loop polls for (`gh issue list --label ralph-ready`). Only issue-backed
  * tasks (a real dispatch_url) qualify; 400 otherwise. Mirrors the label into
  * the row's `tags` on success so the board badge updates immediately.
+ *
+ * 'ralph_approve' (ops#137) resolves the task's `github:<owner>/<repo>#<n>`
+ * key to its `ralph/issue-<n>-*` PR (via `findRalphPr`) and labels it
+ * `ralph-approved`, arming the ralph-gate workflow's human-approved
+ * auto-merge from the board. A PR that's already merged/closed responds
+ * `{ ok: true, note }` rather than erroring; no matching PR is a 404.
  *
  * In dev, the same contract is served by scripts/tasks-middleware.mjs.
  * Success:  { ok: true, ...extra } · Error: { error, code? } 400/401/404/405/500/503

--- a/docs/ai/HANDOFF.md
+++ b/docs/ai/HANDOFF.md
@@ -340,6 +340,13 @@ requires an explicit per-item yes from Adrian (standing rule).
 
 ## Decisions (dated, newest first)
 
+- 2026-07-11 (evening, Adrian): **feature freeze LIFTED** — the fleet burns
+  everything tagged ralph-ready regardless of feature/bug class (everything
+  carries ralph-auto per the same-day standing decision). #44 stays parked
+  until the first manual Monroe preview ship (unmet dependency). The 66
+  legacy BACKLOG.md-era board rows were soft-deleted with a provenance note —
+  GitHub issues are now the board's sole task source, literally.
+
 - 2026-07-11 (Adrian, cockpit session): **everything ralph-auto** — batch
   pre-approval is the ops default; every open `ralph-ready` issue carries
   `ralph-auto` and new tickets get both labels together. Loop PRs merge on

--- a/docs/guardrails/baselines/check-dom-node-budgets.json
+++ b/docs/guardrails/baselines/check-dom-node-budgets.json
@@ -40,12 +40,12 @@
     "src/app/pages/ops/leads/LeadsPage.tsx": 32,
     "src/app/pages/ops/leads/PullLeadsForm.tsx": 19,
     "src/app/pages/ops/projects/ProjectsPage.tsx": 21,
-    "src/app/pages/ops/tasks/TaskActionsMenu.tsx": 12,
+    "src/app/pages/ops/tasks/TaskActionsMenu.tsx": 13,
     "src/app/pages/ops/tasks/TaskRow.tsx": 23,
     "src/app/pages/ops/tasks/TasksPage.tsx": 29,
     "src/app/pages/portal/ClientPortalPage.tsx": 54,
     "src/app/routes.tsx": 28
   },
-  "updatedAt": "2026-07-11T17:18:08.924Z",
-  "sha": "d1b1e5f"
+  "updatedAt": "2026-07-11T17:47:34.539Z",
+  "sha": "6c4cd8a"
 }

--- a/lib/github/issues.mjs
+++ b/lib/github/issues.mjs
@@ -31,9 +31,14 @@ function authHint(status) {
   );
 }
 
-/** Pulls { owner, repo, number } out of an `html_url`-shaped issue link. */
+/**
+ * Pulls { owner, repo, number } out of an `html_url`-shaped issue OR pull
+ * link. PRs share the issue number space and the labels/comments endpoints
+ * address them via /issues/{n} — ralph_approve labels a PR by its html_url
+ * (ops#137 review finding).
+ */
 function parseIssueRef(issueUrl) {
-  const m = /github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/.exec(issueUrl || '');
+  const m = /github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)/.exec(issueUrl || '');
   if (!m) {
     throw new Error(`could not parse owner/repo/issue number from URL: ${issueUrl}`);
   }

--- a/lib/github/issues.mjs
+++ b/lib/github/issues.mjs
@@ -13,6 +13,7 @@
  * @property {(input: { issueUrl: string, body: string }) => Promise<object>} commentOnIssue
  * @property {(input: { issueUrl: string, label: string }) => Promise<object>} addLabel
  * @property {(input: { issueUrl: string, label: string }) => Promise<object>} removeLabel
+ * @property {(input: { owner: string, repo: string, issueNumber: number|string }) => Promise<{ number: number, url: string, state: 'open'|'closed', merged: boolean, head_ref: string, created_at: string } | null>} findRalphPr
  */
 
 const GH_HEADERS = (token) => ({
@@ -205,6 +206,44 @@ export function makeGitHubPort() {
         throw new Error(`HTTP ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`);
       }
       return res.json().catch(() => ({ removed: true }));
+    },
+
+    /**
+     * Finds the Ralph PR for a task's linked issue, by branch prefix
+     * `ralph/issue-<n>-` (the shape `ralph/prompt.md` mandates). Searches all
+     * PR states — not just open — so the "Approve merge" board action
+     * (ops#137) can tell "no PR yet" (404) apart from "PR already
+     * merged/closed" (graceful no-op) instead of treating both as not-found.
+     * Multiple matches (rare — a re-run after a closed PR) resolve to the
+     * newest by `created_at`.
+     * @param {{ owner: string, repo: string, issueNumber: number|string }} input
+     */
+    async findRalphPr({ owner, repo, issueNumber }) {
+      const prefix = `ralph/issue-${issueNumber}-`;
+      const res = await fetch(
+        `https://api.github.com/repos/${owner}/${repo}/pulls?state=all&per_page=100&sort=created&direction=desc`,
+        { headers: GH_HEADERS(token), signal: AbortSignal.timeout(9000) },
+      );
+      if (res.status === 401 || res.status === 403) throw new Error(authHint(res.status));
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`);
+      }
+      const prs = /** @type {any[]} */ (await res.json());
+      const matches = prs.filter(
+        (pr) => typeof pr.head?.ref === 'string' && pr.head.ref.startsWith(prefix),
+      );
+      if (!matches.length) return null;
+      matches.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+      const pr = matches[0];
+      return {
+        number: pr.number,
+        url: pr.html_url,
+        state: pr.state,
+        merged: !!pr.merged_at,
+        head_ref: pr.head.ref,
+        created_at: pr.created_at,
+      };
     },
   };
 }

--- a/lib/tasks/actions.mjs
+++ b/lib/tasks/actions.mjs
@@ -25,6 +25,9 @@ import { getTask, updateTask } from '../supabase/tasks.mjs';
 /** The label the Ralph loop polls for (`ralph/prompt.md` step 1, ops#88). */
 const RALPH_READY_LABEL = 'ralph-ready';
 
+/** The label that arms a Ralph PR's human-approved auto-merge (ralph-gate workflow, ops#137). */
+const RALPH_APPROVED_LABEL = 'ralph-approved';
+
 const SIMPLE = {
   done: () => ({ status: 'done' }),
   reopen: () => ({ status: 'open' }),
@@ -60,8 +63,76 @@ export async function applyTaskAction(sb, { key, action, actor }, { github } = {
   if (action === 'dispatch') return dispatch(sb, key, github);
   if (action === 'ralph_ready_on') return setRalphReady(sb, key, true, github);
   if (action === 'ralph_ready_off') return setRalphReady(sb, key, false, github);
+  if (action === 'ralph_approve') return approveRalphMerge(sb, key, github);
 
   return { status: 400, body: { error: `unknown action: ${action}` } };
+}
+
+/** Parses a `github:<owner>/<repo>#<n>` task key into its parts, or null. */
+function parseGithubTaskKey(key) {
+  const m = /^github:([^/]+)\/([^#]+)#(\d+)$/.exec(key || '');
+  if (!m) return null;
+  return { owner: m[1], repo: m[2], number: m[3] };
+}
+
+/**
+ * The board-only "Approve merge" action (ops#137, board-only lifecycle
+ * candidate 6): labels the linked `ralph/issue-<n>-*` PR `ralph-approved`,
+ * which arms the ralph-gate workflow's human-approved auto-merge — the
+ * approval step no longer requires a trip to the GitHub tab. Only
+ * github:*-keyed tasks qualify — the key is where `owner/repo/#n` comes from
+ * to resolve the PR via `findRalphPr`.
+ *
+ * A PR that's already merged or closed is reported back as a graceful no-op
+ * (not an error) — the approval intent is moot, not failed.
+ */
+async function approveRalphMerge(sb, key, github) {
+  if (!github) {
+    return {
+      status: 503,
+      body: {
+        error: 'GITHUB_TOKEN not set — needed to label the Ralph PR.',
+        code: 'ENV_MISSING_GITHUB_TOKEN',
+      },
+    };
+  }
+
+  const { data: task, error: fetchError } = await getTask(sb, key);
+  if (fetchError || !task) return { status: 404, body: { error: 'task not found' } };
+
+  const ref = parseGithubTaskKey(task.key);
+  if (!ref) {
+    return {
+      status: 400,
+      body: { error: 'task is not a github-tracked issue — cannot resolve its Ralph PR.' },
+    };
+  }
+
+  let pr;
+  try {
+    pr = await github.findRalphPr({ owner: ref.owner, repo: ref.repo, issueNumber: ref.number });
+  } catch (err) {
+    return githubPortError(err, { action: 'PR lookup', code: 'GITHUB_PR_LOOKUP_FAILED' });
+  }
+
+  if (!pr) {
+    return {
+      status: 404,
+      body: { error: `no PR found for branch prefix ralph/issue-${ref.number}-` },
+    };
+  }
+
+  if (pr.merged) return { status: 200, body: { ok: true, note: 'already merged', prUrl: pr.url } };
+  if (pr.state === 'closed')
+    return { status: 200, body: { ok: true, note: 'closed', prUrl: pr.url } };
+
+  try {
+    await github.addLabel({ issueUrl: pr.url, label: RALPH_APPROVED_LABEL });
+  } catch (err) {
+    return githubPortError(err, { action: 'label update', code: 'GITHUB_LABEL_FAILED' });
+  }
+
+  return { status: 200, body: { ok: true, prUrl: pr.url } };
 }
 
 /**

--- a/progress.txt
+++ b/progress.txt
@@ -211,3 +211,36 @@
   approval-card.tsx, src/app/pages/admin/useApprovalsInbox.ts,
   docs/guardrails/baselines/check-dom-node-budgets.json.
 - Branch ralph/issue-135-derive-work-state.
+
+## Issue #137 — Approve-merge card action (2026-07-11)
+- New action ralph_approve in lib/tasks/actions.mjs, folded into the existing
+  POST /api/task-action (no new api/*.ts file — Vercel Hobby cap), mirroring
+  the shipped #97 ralph_ready_on/off pattern: parse owner/repo/#n from the
+  task's github:<owner>/<repo>#<n> key, resolve the ralph/issue-<n>-* PR via
+  a new findRalphPr port method, addLabel 'ralph-approved' on success.
+- lib/github/issues.mjs: findRalphPr({owner, repo, issueNumber}) fetches
+  state=all pulls (not just open) so a merged/closed match can be told apart
+  from no-PR-yet rather than both reading as not-found; multi-match resolves
+  to newest by created_at. Returns {number, url, state, merged, head_ref,
+  created_at} or null.
+- actions.mjs::approveRalphMerge: no port -> 503 ENV_MISSING_GITHUB_TOKEN;
+  task missing -> 404; non-github: key -> 400; no PR match -> 404 naming the
+  expected branch prefix; PR merged/closed -> graceful {ok:true, note} (not
+  an error — approval intent is moot, not failed); open PR -> addLabel ->
+  {ok:true, prUrl}. Reuses the existing githubPortError 401/403 mapper.
+- UI: TaskActionsMenu.tsx adds an "Approve merge" item gated on
+  t.key.startsWith('github:') (v1 scope per the issue — relies on the
+  graceful no-PR/merged/closed responses rather than pre-filtering PR state
+  client-side). types.ts + api/task-action.ts doc comment updated.
+- Tests: tests/api/github-issues.test.ts (new findRalphPr describe block —
+  no-match, open match, merged, closed-not-merged, multi-match newest-wins,
+  401/403), tests/api/task-actions.test.ts (new ralph_approve describe block
+  mirroring ralph_ready_on/off's coverage shape).
+- Re-locked docs/guardrails/baselines/check-dom-node-budgets.json:
+  TaskActionsMenu.tsx 12->13 (one new Menu.Item, ratchet --update).
+- Gate green: typecheck + test (523 passed, incl. 15 new) + lint.
+- Files: lib/github/issues.mjs, lib/tasks/actions.mjs, api/task-action.ts,
+  src/app/pages/ops/tasks/{types.ts,TaskActionsMenu.tsx}, tests/api/
+  {github-issues.test.ts,task-actions.test.ts}, docs/guardrails/baselines/
+  check-dom-node-budgets.json.
+- Branch ralph/issue-137-approve-merge-action.

--- a/src/app/pages/ops/tasks/TaskActionsMenu.tsx
+++ b/src/app/pages/ops/tasks/TaskActionsMenu.tsx
@@ -36,9 +36,7 @@ export function TaskActionsMenu({ task: t, busy, onAction }: TaskActionsMenuProp
         {t.status !== 'done' && (
           <Menu.Item onSelect={() => onAction(t.key, 'done')}>Mark done</Menu.Item>
         )}
-        {ref && (
-          <Menu.Item onSelect={() => void copyText(ref)}>Copy {ref}</Menu.Item>
-        )}
+        {ref && <Menu.Item onSelect={() => void copyText(ref)}>Copy {ref}</Menu.Item>}
         <Menu.Separator />
         <Menu.Item onSelect={() => onAction(t.key, t.auto_ok ? 'auto_off' : 'auto_on')}>
           {t.auto_ok ? 'Auto-dispatch: on → turn off' : 'Auto-dispatch: off → turn on'}
@@ -56,6 +54,14 @@ export function TaskActionsMenu({ task: t, busy, onAction }: TaskActionsMenuProp
             title="Adds/removes the ralph-ready label on the linked GitHub issue — the Ralph loop picks up ralph-ready issues automatically."
           >
             {ralphReady ? 'Ralph-ready: on → turn off' : 'Ralph-ready: off → turn on'}
+          </Menu.Item>
+        )}
+        {t.key.startsWith('github:') && (
+          <Menu.Item
+            onSelect={() => onAction(t.key, 'ralph_approve')}
+            title="Labels the linked ralph/issue-N PR ralph-approved, arming the ralph-gate workflow's auto-merge."
+          >
+            Approve merge
           </Menu.Item>
         )}
         <Menu.Separator />

--- a/src/app/pages/ops/tasks/types.ts
+++ b/src/app/pages/ops/tasks/types.ts
@@ -66,7 +66,8 @@ export type TaskAction =
   | 'queue'
   | 'unqueue'
   | 'ralph_ready_on'
-  | 'ralph_ready_off';
+  | 'ralph_ready_off'
+  | 'ralph_approve';
 
 export interface TasksResponse {
   tasks: Task[];

--- a/tests/api/github-issues.test.ts
+++ b/tests/api/github-issues.test.ts
@@ -206,18 +206,53 @@ describe('makeGitHubPort().findRalphPr', () => {
   });
 
   it('throws an actionable error on 401/403', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue({
-        ok: false,
-        status: 401,
-        headers: { get: () => null },
-        text: async () => '',
-      });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      text: async () => '',
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
       makeGitHubPort().findRalphPr({ owner: 'hirobius', repo: 'ops', issueNumber: 137 }),
     ).rejects.toThrow(/GITHUB_TOKEN/);
+  });
+});
+
+describe('makeGitHubPort().addLabel — pull request URLs (ops#137 review finding)', () => {
+  beforeEach(() => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('labels a PR via its /pull/N URL (PRs are issues to the labels API)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(pageResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await makeGitHubPort().addLabel({
+      issueUrl: 'https://github.com/hirobius/ops/pull/154',
+      label: 'ralph-approved',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.github.com/repos/hirobius/ops/issues/154/labels');
+  });
+
+  it('still labels a plain issue URL unchanged', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(pageResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await makeGitHubPort().addLabel({
+      issueUrl: 'https://github.com/hirobius/ops/issues/99',
+      label: 'ralph-ready',
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.github.com/repos/hirobius/ops/issues/99/labels');
   });
 });

--- a/tests/api/github-issues.test.ts
+++ b/tests/api/github-issues.test.ts
@@ -94,3 +94,130 @@ describe('makeGitHubPort().listOpenIssues — pagination', () => {
     expect(issues[0]).toMatchObject({ repo: 'hirobius/ops', number: 1 });
   });
 });
+
+function rawPr(
+  number,
+  {
+    ref = `ralph/issue-137-approve-merge`,
+    state = 'open',
+    mergedAt = null,
+    createdAt = '2026-07-01T00:00:00Z',
+  } = {},
+) {
+  return {
+    number,
+    html_url: `https://github.com/hirobius/ops/pull/${number}`,
+    state,
+    merged_at: mergedAt,
+    created_at: createdAt,
+    head: { ref },
+  };
+}
+
+describe('makeGitHubPort().findRalphPr', () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    process.env.GITHUB_TOKEN = originalToken;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when no PR matches the branch prefix', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(pageResponse([rawPr(1, { ref: 'unrelated-branch' })]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pr = await makeGitHubPort().findRalphPr({
+      owner: 'hirobius',
+      repo: 'ops',
+      issueNumber: 137,
+    });
+
+    expect(pr).toBeNull();
+  });
+
+  it('finds an open PR matching the ralph/issue-<n>- prefix', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(pageResponse([rawPr(9)]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pr = await makeGitHubPort().findRalphPr({
+      owner: 'hirobius',
+      repo: 'ops',
+      issueNumber: 137,
+    });
+
+    expect(pr).toMatchObject({
+      number: 9,
+      url: 'https://github.com/hirobius/ops/pull/9',
+      state: 'open',
+      merged: false,
+    });
+  });
+
+  it('reports a merged PR as merged rather than dropping it', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        pageResponse([rawPr(9, { state: 'closed', mergedAt: '2026-07-02T00:00:00Z' })]),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pr = await makeGitHubPort().findRalphPr({
+      owner: 'hirobius',
+      repo: 'ops',
+      issueNumber: 137,
+    });
+
+    expect(pr).toMatchObject({ number: 9, state: 'closed', merged: true });
+  });
+
+  it('reports a closed-not-merged PR distinctly', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(pageResponse([rawPr(9, { state: 'closed' })]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pr = await makeGitHubPort().findRalphPr({
+      owner: 'hirobius',
+      repo: 'ops',
+      issueNumber: 137,
+    });
+
+    expect(pr).toMatchObject({ number: 9, state: 'closed', merged: false });
+  });
+
+  it('resolves multiple matches to the newest by created_at', async () => {
+    const older = rawPr(5, { createdAt: '2026-06-01T00:00:00Z' });
+    const newer = rawPr(9, { createdAt: '2026-07-01T00:00:00Z' });
+    const fetchMock = vi.fn().mockResolvedValue(pageResponse([older, newer]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const pr = await makeGitHubPort().findRalphPr({
+      owner: 'hirobius',
+      repo: 'ops',
+      issueNumber: 137,
+    });
+
+    expect(pr?.number).toBe(9);
+  });
+
+  it('throws an actionable error on 401/403', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: { get: () => null },
+        text: async () => '',
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      makeGitHubPort().findRalphPr({ owner: 'hirobius', repo: 'ops', issueNumber: 137 }),
+    ).rejects.toThrow(/GITHUB_TOKEN/);
+  });
+});

--- a/tests/api/task-actions.test.ts
+++ b/tests/api/task-actions.test.ts
@@ -287,3 +287,144 @@ describe('applyTaskAction — ralph_ready_on/off (injected GitHub port)', () => 
     expect((result.body as { code: string }).code).toBe('GITHUB_LABEL_FAILED');
   });
 });
+
+describe('applyTaskAction — ralph_approve (injected GitHub port, ops#137)', () => {
+  const task = { key: 'github:hirobius/ops#137', title: 'Approve merge action' };
+
+  it('503s when no port is configured (no GITHUB_TOKEN)', async () => {
+    const { sb } = makeSb({ task });
+    expect(
+      await applyTaskAction(
+        sb,
+        { key: 'github:hirobius/ops#137', action: 'ralph_approve' },
+        { github: null },
+      ),
+    ).toMatchObject({ status: 503, body: { code: 'ENV_MISSING_GITHUB_TOKEN' } });
+  });
+
+  it('404s when the task is missing', async () => {
+    const { sb } = makeSb({ task: null });
+    const github = { findRalphPr: async () => null, addLabel: async () => ({}) };
+    expect(
+      await applyTaskAction(sb, { key: 'nope', action: 'ralph_approve' }, { github }),
+    ).toMatchObject({ status: 404 });
+  });
+
+  it('400s when the task is not a github-tracked issue', async () => {
+    const { sb } = makeSb({ task: { key: 't1', title: 'Do it' } });
+    const github = { findRalphPr: async () => null, addLabel: async () => ({}) };
+    expect(
+      await applyTaskAction(sb, { key: 't1', action: 'ralph_approve' }, { github }),
+    ).toMatchObject({ status: 400 });
+  });
+
+  it('404s naming the expected branch prefix when no PR is found', async () => {
+    const { sb } = makeSb({ task });
+    const github = { findRalphPr: async () => null, addLabel: async () => ({}) };
+    const result = await applyTaskAction(
+      sb,
+      { key: 'github:hirobius/ops#137', action: 'ralph_approve' },
+      { github },
+    );
+    expect(result.status).toBe(404);
+    expect((result.body as { error: string }).error).toContain('ralph/issue-137-');
+  });
+
+  it('labels the open PR ralph-approved via the port', async () => {
+    const { sb } = makeSb({ task });
+    const calls: Array<{ issueUrl: string; label: string }> = [];
+    const github = {
+      findRalphPr: async (i: { owner: string; repo: string; issueNumber: string }) => {
+        expect(i).toEqual({ owner: 'hirobius', repo: 'ops', issueNumber: '137' });
+        return {
+          number: 9,
+          url: 'https://github.com/hirobius/ops/pull/9',
+          state: 'open',
+          merged: false,
+        };
+      },
+      addLabel: async (i: { issueUrl: string; label: string }) => {
+        calls.push(i);
+        return {};
+      },
+    };
+    const result = await applyTaskAction(
+      sb,
+      { key: 'github:hirobius/ops#137', action: 'ralph_approve' },
+      { github },
+    );
+    expect(calls[0]).toEqual({
+      issueUrl: 'https://github.com/hirobius/ops/pull/9',
+      label: 'ralph-approved',
+    });
+    expect(result).toEqual({
+      status: 200,
+      body: { ok: true, prUrl: 'https://github.com/hirobius/ops/pull/9' },
+    });
+  });
+
+  it('gracefully no-ops when the PR is already merged', async () => {
+    const { sb } = makeSb({ task });
+    const github = {
+      findRalphPr: async () => ({
+        number: 9,
+        url: 'https://github.com/hirobius/ops/pull/9',
+        state: 'closed',
+        merged: true,
+      }),
+      addLabel: async () => {
+        throw new Error('should not be called');
+      },
+    };
+    const result = await applyTaskAction(
+      sb,
+      { key: 'github:hirobius/ops#137', action: 'ralph_approve' },
+      { github },
+    );
+    expect(result).toEqual({
+      status: 200,
+      body: { ok: true, note: 'already merged', prUrl: 'https://github.com/hirobius/ops/pull/9' },
+    });
+  });
+
+  it('gracefully no-ops when the PR is closed without merging', async () => {
+    const { sb } = makeSb({ task });
+    const github = {
+      findRalphPr: async () => ({
+        number: 9,
+        url: 'https://github.com/hirobius/ops/pull/9',
+        state: 'closed',
+        merged: false,
+      }),
+      addLabel: async () => {
+        throw new Error('should not be called');
+      },
+    };
+    const result = await applyTaskAction(
+      sb,
+      { key: 'github:hirobius/ops#137', action: 'ralph_approve' },
+      { github },
+    );
+    expect(result).toEqual({
+      status: 200,
+      body: { ok: true, note: 'closed', prUrl: 'https://github.com/hirobius/ops/pull/9' },
+    });
+  });
+
+  it('502s with a token-rejected hint when the port throws 401/403', async () => {
+    const { sb } = makeSb({ task });
+    const github = {
+      findRalphPr: async () => {
+        throw new Error('HTTP 401');
+      },
+      addLabel: async () => ({}),
+    };
+    const result = await applyTaskAction(
+      sb,
+      { key: 'github:hirobius/ops#137', action: 'ralph_approve' },
+      { github },
+    );
+    expect(result.status).toBe(502);
+    expect((result.body as { code: string }).code).toBe('GITHUB_TOKEN_REJECTED');
+  });
+});


### PR DESCRIPTION
## Linked unit

Unit: n/a (orchestration retired). Closes #137; supersedes the loop's PR #154 (its branch is merged into this one — the work and commit credit are preserved, only the one bug is fixed on top).

## Summary

The gate's AI reviewer correctly blocked PR #154: `approveRalphMerge` feeds a PR's `html_url` (`/pull/N`) into `addLabel`, whose `parseIssueRef` matched only `/issues/N` — the action's single success path always threw, and the stubbed task-action tests couldn't see it. PRs share the issue number space and the labels/comments endpoints address them via `/issues/{n}`, so the parser now accepts both URL shapes. Red-first test exercises the **real** parser with a pull URL (closing the exact test gap the reviewer named); the issue-URL path is pinned unchanged.

Also records tonight's operator decisions in HANDOFF: feature freeze lifted; #44 stays parked pending the first manual Monroe ship; the 66 legacy backlog board rows retired.

## Validator output

```
vitest: 45 files, 519 tests — all green (incl. the two new pull-URL parser cases)
pre-commit: full registry-gate chain green (Lighthouse retried within its own budget); pre-push typecheck+tests green. No --no-verify.
```

## Breaking change

- [ ] No — parser widened, existing behavior pinned by test.

## Screenshots (if visual)

- [x] N/A — the UI menu item shipped in #154's commits; behavior verified by tests.

## Checklist

- [x] `Co-Authored-By` trailer present
- [ ] Orchestration — n/a, retired
- [x] No `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE)_