### PR TITLE
chore(ralph): re-sync lib.sh — repo_slug tokenized-URL fix (ralph#9)

### DIFF
--- a/ralph/lib.sh
+++ b/ralph/lib.sh
@@ -32,7 +32,17 @@ fi
 : "${RALPH_DRY_RUN:=0}"
 
 repo_slug() {
-  git remote get-url origin | sed -E 's#^(git@github\.com:|https://github\.com/)##; s#\.git$##'
+  # CI first: $GITHUB_REPOSITORY is the runner's canonical slug. The checkout's
+  # origin URL is NOT trustworthy mid-job — claude-code-action rewrites it to
+  # https://x-access-token:<token>@github.com/..., which the sed below didn't
+  # strip, so every "repos/$(repo_slug)/..." API path built after the model
+  # step 404'd SILENTLY (ralph#8: claim refs never released, attempt-budget
+  # resets never seen). The local fallback also strips embedded credentials.
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    echo "$GITHUB_REPOSITORY"
+    return 0
+  fi
+  git remote get-url origin | sed -E 's#^(git@github\.com:|https://([^@/]+@)?github\.com/)##; s#\.git$##'
 }
 
 default_branch() {
@@ -189,7 +199,10 @@ claim_issue() {
 release_claim() {
   local n=$1
   [ "$RALPH_DRY_RUN" = "1" ] && return 0
-  delete_claim_ref "$n" || true
+  # Fail loud (stderr, non-fatal): a leaked claim ref blocks re-queueing the
+  # issue until the stale-TTL reclaim — never let that happen silently again.
+  delete_claim_ref "$n" ||
+    echo "ralph: WARNING — could not delete claim ref for #$n; it will block re-claims until the stale-TTL reclaim." >&2
   gh issue edit "$n" --remove-label ralph-wip >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
## Summary
- Re-syncs `ralph/lib.sh` byte-identical to `hirobius/ralph` `kit/lib.sh` @ `5538033` (ralph#9, the ralph#8 root-cause fix): `repo_slug()` now prefers `$GITHUB_REPOSITORY` in CI and strips credential-embedded origin URLs (claude-code-action rewrites `origin` mid-job), so claim refs actually release after the model step and the ready-label attempt-budget reset is seen. Same class of orphaned claim refs exists here; they self-recover via the stale-TTL reclaim once this lands.

## Test plan
- [x] `cmp` — byte-identical to canonical kit (the gate's kit-drift check enforces the same)
- [x] Shell-only change to the vendored kit; no app surface touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCZaKTNxWSgJaLLb3zVCsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCZaKTNxWSgJaLLb3zVCsd)_