### PR TITLE
feat(tasks): Ralph fleet panel — live runs + selector-ordered queue on the board (#112)

### DIFF
--- a/api/tasks.ts
+++ b/api/tasks.ts
@@ -31,15 +31,26 @@
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { withOpsHandler, withServiceClient, messageOf, type HandlerResult } from '../lib/api/handler.js';
+import {
+  withOpsHandler,
+  withServiceClient,
+  messageOf,
+  type HandlerResult,
+} from '../lib/api/handler.js';
 import { listTasks, upsertTasks } from '../lib/supabase/tasks.mjs';
 import { mapIssuesToTasks } from '../lib/tasks/import-issues.mjs';
+import { orderRalphQueue } from '../lib/tasks/ralph-queue.mjs';
 import { makeGitHubPort } from '../lib/github/issues.mjs';
 
 const DEFAULT_LIMIT = 1000;
 const MAX_LIMIT = 2000;
 
+/** The repos whose Ralph loops the board's fleet panel watches (ops#112). */
+const FLEET_REPOS = ['hirobius/ops', 'hirobius/hds', 'hirobius/site-engine'];
+
 export async function tasksHandler(sb: SupabaseClient, req: VercelRequest): Promise<HandlerResult> {
+  if (pick(req.query['ralph']) === '1') return ralphStatusHandler();
+
   const limit = clampLimit(pick(req.query['limit']));
   const includeDeleted = pick(req.query['include_deleted']) === '1';
 
@@ -48,7 +59,45 @@ export async function tasksHandler(sb: SupabaseClient, req: VercelRequest): Prom
   return { status: 200, body: { tasks: data ?? [] } };
 }
 
-export async function importIssuesHandler(sb: SupabaseClient, _req: VercelRequest): Promise<HandlerResult> {
+/**
+ * GET /api/tasks?ralph=1 — the fleet Ralph panel's read (ops#112): recent runs
+ * + the selector-ordered queue per fleet repo, straight from GitHub (labels ARE
+ * the loop's state store; Supabase isn't consulted). Folded in here to stay
+ * under the Vercel Hobby function cap. Per-repo GitHub failures surface as
+ * `errors` entries (fail-soft per repo, loud per message).
+ */
+export async function ralphStatusHandler(): Promise<HandlerResult> {
+  const gh = makeGitHubPort();
+  if (!gh) {
+    return {
+      status: 503,
+      body: {
+        error:
+          'GITHUB_TOKEN not set — needed for the Ralph fleet panel. Add it in Vercel → ' +
+          'Settings → Environment Variables (Production + Preview), then redeploy.',
+        code: 'ENV_MISSING_GITHUB_TOKEN',
+      },
+    };
+  }
+  try {
+    const [runs, ready] = await Promise.all([
+      gh.listRalphRuns({ repos: FLEET_REPOS }),
+      gh.listRalphReadyIssues({ repos: FLEET_REPOS }),
+    ]);
+    const queue = orderRalphQueue(ready.flatMap((r) => r.issues));
+    const errors = [...runs, ...ready]
+      .filter((e) => e.error)
+      .map((e) => ({ repo: e.repo, error: e.error as string }));
+    return { status: 200, body: { runs, queue, errors } };
+  } catch (err) {
+    return { status: 502, body: { error: messageOf(err), code: 'GITHUB_RALPH_STATUS_FAILED' } };
+  }
+}
+
+export async function importIssuesHandler(
+  sb: SupabaseClient,
+  _req: VercelRequest,
+): Promise<HandlerResult> {
   const gh = makeGitHubPort();
   if (!gh) {
     return {

--- a/docs/guardrails/baselines/check-dom-node-budgets.json
+++ b/docs/guardrails/baselines/check-dom-node-budgets.json
@@ -40,12 +40,13 @@
     "src/app/pages/ops/leads/LeadsPage.tsx": 32,
     "src/app/pages/ops/leads/PullLeadsForm.tsx": 19,
     "src/app/pages/ops/projects/ProjectsPage.tsx": 21,
+    "src/app/pages/ops/tasks/RalphPanel.tsx": 21,
     "src/app/pages/ops/tasks/TaskActionsMenu.tsx": 13,
     "src/app/pages/ops/tasks/TaskRow.tsx": 23,
-    "src/app/pages/ops/tasks/TasksPage.tsx": 29,
+    "src/app/pages/ops/tasks/TasksPage.tsx": 30,
     "src/app/pages/portal/ClientPortalPage.tsx": 54,
     "src/app/routes.tsx": 28
   },
-  "updatedAt": "2026-07-11T17:47:34.539Z",
-  "sha": "6c4cd8a"
+  "updatedAt": "2026-07-12T07:43:05.903Z",
+  "sha": "f870eed"
 }

--- a/lib/github/issues.mjs
+++ b/lib/github/issues.mjs
@@ -14,6 +14,8 @@
  * @property {(input: { issueUrl: string, label: string }) => Promise<object>} addLabel
  * @property {(input: { issueUrl: string, label: string }) => Promise<object>} removeLabel
  * @property {(input: { owner: string, repo: string, issueNumber: number|string }) => Promise<{ number: number, url: string, state: 'open'|'closed', merged: boolean, head_ref: string, created_at: string } | null>} findRalphPr
+ * @property {(input: { repos: string[] }) => Promise<Array<{ repo: string, runs: Array<{ number: number, status: string, conclusion: string|null, title: string, url: string, started_at: string }>, error?: string }>>} listRalphRuns
+ * @property {(input: { repos: string[] }) => Promise<Array<{ repo: string, issues: Array<{ repo: string, number: number, title: string, url: string, labels: string[] }>, error?: string }>>} listRalphReadyIssues
  */
 
 const GH_HEADERS = (token) => ({
@@ -249,6 +251,91 @@ export function makeGitHubPort() {
         head_ref: pr.head.ref,
         created_at: pr.created_at,
       };
+    },
+
+    /**
+     * Recent Ralph workflow runs per fleet repo (ops#112's "now running" lane).
+     * One Actions query per repo, batched; a failing repo becomes an `error`
+     * entry (per-repo fail-soft — the panel must still render the healthy
+     * repos, and the error string names the failure for the operator).
+     */
+    async listRalphRuns({ repos }) {
+      return Promise.all(
+        repos.map(async (fullRepo) => {
+          try {
+            const res = await fetch(
+              `https://api.github.com/repos/${fullRepo}/actions/workflows/ralph.yml/runs?per_page=5`,
+              { headers: GH_HEADERS(token), signal: AbortSignal.timeout(9000) },
+            );
+            if (res.status === 401 || res.status === 403) throw new Error(authHint(res.status));
+            if (!res.ok) {
+              const text = await res.text().catch(() => '');
+              throw new Error(`HTTP ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`);
+            }
+            const body = /** @type {{ workflow_runs?: any[] }} */ (await res.json());
+            return {
+              repo: fullRepo,
+              runs: (body.workflow_runs ?? []).map((r) => ({
+                number: r.run_number,
+                status: r.status,
+                conclusion: r.conclusion ?? null,
+                title: r.display_title,
+                url: r.html_url,
+                started_at: r.run_started_at,
+              })),
+            };
+          } catch (err) {
+            return {
+              repo: fullRepo,
+              runs: [],
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }),
+      );
+    },
+
+    /**
+     * Open `ralph-ready` issues per fleet repo (ops#112's queue lane — the raw
+     * eligible set; ordering/exclusions live in lib/tasks/ralph-queue.mjs so
+     * they stay selector-parity-tested). Drops PRs; same per-repo fail-soft
+     * shape as listRalphRuns.
+     */
+    async listRalphReadyIssues({ repos }) {
+      return Promise.all(
+        repos.map(async (fullRepo) => {
+          try {
+            const res = await fetch(
+              `https://api.github.com/repos/${fullRepo}/issues?labels=ralph-ready&state=open&per_page=100`,
+              { headers: GH_HEADERS(token), signal: AbortSignal.timeout(9000) },
+            );
+            if (res.status === 401 || res.status === 403) throw new Error(authHint(res.status));
+            if (!res.ok) {
+              const text = await res.text().catch(() => '');
+              throw new Error(`HTTP ${res.status}${text ? ` — ${text.slice(0, 300)}` : ''}`);
+            }
+            const issues = /** @type {any[]} */ (await res.json());
+            return {
+              repo: fullRepo,
+              issues: issues
+                .filter((i) => !i.pull_request)
+                .map((i) => ({
+                  repo: fullRepo,
+                  number: i.number,
+                  title: i.title,
+                  url: i.html_url,
+                  labels: (i.labels ?? []).map((l) => (typeof l === 'string' ? l : l.name)),
+                })),
+            };
+          } catch (err) {
+            return {
+              repo: fullRepo,
+              issues: [],
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }),
+      );
     },
   };
 }

--- a/lib/tasks/ralph-queue.mjs
+++ b/lib/tasks/ralph-queue.mjs
@@ -1,0 +1,35 @@
+/**
+ * lib/tasks/ralph-queue.mjs — pure, selector-parity ordering for the board's
+ * Ralph panel (ops#112).
+ *
+ * MUST mirror ralph/next.sh:26-32 exactly: eligible = open ralph-ready issues
+ * minus blocked/needs-adrian/ralph-parked; order = p0→p3 label then ascending
+ * issue number, unlabeled priority last. ralph-wip stays in the queue slot it
+ * owns (the claim is the real lock) but is annotated so the UI can mark it as
+ * "being worked" — the runs lane shows the live iteration.
+ */
+
+const EXCLUDE = new Set(['blocked', 'needs-adrian', 'ralph-parked']);
+const PRIO = { p0: 0, p1: 1, p2: 2, p3: 3 };
+
+/**
+ * @param {Array<{repo: string, number: number, title: string, url: string, labels: string[]}>} issues
+ * @returns {Array<{repo, number, title, url, prio: string|null, wip: boolean}>}
+ */
+export function orderRalphQueue(issues) {
+  return issues
+    .filter((i) => !i.labels.some((l) => EXCLUDE.has(l)))
+    .map((i) => ({
+      repo: i.repo,
+      number: i.number,
+      title: i.title,
+      url: i.url,
+      prio: i.labels.find((l) => l in PRIO) ?? null,
+      wip: i.labels.includes('ralph-wip'),
+    }))
+    .sort((a, b) => rank(a) - rank(b) || a.number - b.number);
+}
+
+function rank(i) {
+  return i.prio != null ? PRIO[i.prio] : 9;
+}

--- a/src/app/pages/ops/tasks/RalphPanel.tsx
+++ b/src/app/pages/ops/tasks/RalphPanel.tsx
@@ -1,0 +1,220 @@
+/* hds-bypass: ops-internal page. Inline styles intentional for ops dashboard. */
+
+/**
+ * RalphPanel — live fleet view of the autonomous loop (ops#112).
+ *
+ * Two lanes, straight from GitHub via GET /api/tasks?ralph=1 (labels are the
+ * loop's state store): "now" — the most recent Ralph run per fleet repo — and
+ * "queue" — eligible ralph-ready issues in the EXACT deterministic selector
+ * order (lib/tasks/ralph-queue.mjs mirrors ralph/next.sh). Per-repo fetch
+ * failures render as loud per-repo lines; the healthy repos still show.
+ */
+
+import { Badge } from '@hirobius/design-system';
+import hds from '@hirobius/design-system/tokens';
+import type { ComponentProps, CSSProperties } from 'react';
+import { usePoll } from '../../../lib/usePoll';
+import { relTimeNow } from './taskMeta';
+
+type BadgeTone = NonNullable<ComponentProps<typeof Badge>['tone']>;
+
+interface RalphRun {
+  number: number;
+  status: string;
+  conclusion: string | null;
+  title: string;
+  url: string;
+  started_at: string;
+}
+interface RalphRepoRuns {
+  repo: string;
+  runs: RalphRun[];
+  error?: string;
+}
+interface RalphQueueItem {
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  prio: string | null;
+  wip: boolean;
+}
+interface RalphStatus {
+  runs: RalphRepoRuns[];
+  queue: RalphQueueItem[];
+  errors: { repo: string; error: string }[];
+}
+
+const POLL_MS = 45_000;
+const QUEUE_SHOWN = 8;
+
+function shortRepo(full: string): string {
+  return full.slice(full.indexOf('/') + 1);
+}
+
+function runChip(entry: RalphRepoRuns): { tone: BadgeTone; label: string; url?: string } {
+  if (entry.error) return { tone: 'danger', label: 'unreachable' };
+  const latest = entry.runs[0];
+  if (!latest) return { tone: 'neutral', label: 'never run' };
+  if (latest.status === 'in_progress' || latest.status === 'queued') {
+    return { tone: 'inProgress', label: `running #${latest.number}`, url: latest.url };
+  }
+  if (latest.conclusion === 'success') {
+    return {
+      tone: 'success',
+      label: `idle · last ✓ ${relTimeNow(latest.started_at)}`,
+      url: latest.url,
+    };
+  }
+  return {
+    tone: 'danger',
+    label: `last run ${latest.conclusion ?? latest.status}`,
+    url: latest.url,
+  };
+}
+
+export function RalphPanel() {
+  const { data, isOffline, isInitialLoading } = usePoll<RalphStatus>(
+    async (signal) => {
+      const res = await fetch('/api/tasks?ralph=1', { signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return (await res.json()) as RalphStatus;
+    },
+    { intervalMs: POLL_MS, offlineIntervalMs: POLL_MS * 2, requestTimeoutMs: 15_000 },
+  );
+
+  return (
+    <section style={s.panel} aria-labelledby="ralph-panel-label" data-role="ralph-panel">
+      <header style={s.header}>
+        <span id="ralph-panel-label" style={s.label}>
+          Ralph — fleet
+        </span>
+        {isInitialLoading && <span style={s.quiet}>loading…</span>}
+        {isOffline && <span style={s.quiet}>unreachable — retrying</span>}
+      </header>
+
+      {data && (
+        <div style={s.body}>
+          <div style={s.repoRow}>
+            {data.runs.map((entry) => {
+              const chip = runChip(entry);
+              return (
+                <span key={entry.repo} style={s.repoCell}>
+                  <span style={s.repoName}>{shortRepo(entry.repo)}</span>
+                  {chip.url ? (
+                    <a href={chip.url} target="_blank" rel="noreferrer" style={s.chipLink}>
+                      <Badge tone={chip.tone}>{chip.label}</Badge>
+                    </a>
+                  ) : (
+                    <Badge tone={chip.tone}>{chip.label}</Badge>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+
+          {data.errors.map((e) => (
+            <p key={e.repo} style={s.errorLine}>
+              {shortRepo(e.repo)}: {e.error}
+            </p>
+          ))}
+
+          <ol style={s.queue}>
+            {data.queue.slice(0, QUEUE_SHOWN).map((q) => (
+              <li key={`${q.repo}#${q.number}`} style={s.queueItem}>
+                <a href={q.url} target="_blank" rel="noreferrer" style={s.queueLink}>
+                  <span style={s.queueNum}>
+                    {shortRepo(q.repo)}#{q.number}
+                  </span>{' '}
+                  {q.title}
+                </a>
+                {q.prio && (
+                  <Badge
+                    tone={q.prio === 'p0' ? 'danger' : q.prio === 'p1' ? 'warning' : 'neutral'}
+                  >
+                    {q.prio}
+                  </Badge>
+                )}
+                {q.wip && <Badge tone="inProgress">working</Badge>}
+              </li>
+            ))}
+            {data.queue.length === 0 && (
+              <li style={s.quiet}>queue empty — tag something ralph-ready</li>
+            )}
+          </ol>
+          {data.queue.length > QUEUE_SHOWN && (
+            <span style={s.quiet}>+{data.queue.length - QUEUE_SHOWN} more in queue</span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+const s = {
+  panel: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: hds.space.px8,
+    padding: hds.space.px12,
+    border: '1px solid var(--semantic-color-border-default)',
+    borderRadius: hds.borderRadius[8],
+    background: 'var(--semantic-color-surface-raised)',
+  },
+  header: { display: 'flex', alignItems: 'baseline', gap: hds.space.px8 },
+  label: {
+    fontFamily: hds.monoFamily,
+    fontSize: hds.fontSize.xs,
+    textTransform: 'uppercase' as const, // eyebrow-ok: panel kicker
+    letterSpacing: '0.08em',
+    color: 'var(--semantic-color-content-secondary)',
+  },
+  quiet: {
+    fontFamily: hds.monoFamily,
+    fontSize: hds.fontSize.xs,
+    color: 'var(--semantic-color-content-disabled)',
+  },
+  body: { display: 'flex', flexDirection: 'column' as const, gap: hds.space.px8 },
+  repoRow: {
+    display: 'flex',
+    gap: hds.space.px16,
+    flexWrap: 'wrap' as const,
+    alignItems: 'center',
+  },
+  repoCell: { display: 'inline-flex', alignItems: 'center', gap: hds.space.px4 },
+  repoName: {
+    fontFamily: hds.monoFamily,
+    fontSize: hds.fontSize.xs,
+    color: 'var(--semantic-color-content-primary)',
+  },
+  chipLink: { textDecoration: 'none' },
+  errorLine: {
+    margin: 0,
+    fontFamily: hds.monoFamily,
+    fontSize: hds.fontSize.xs,
+    color: 'var(--semantic-color-content-danger, #b3423a)',
+  },
+  queue: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: hds.space.px4,
+  },
+  queueItem: { display: 'flex', alignItems: 'center', gap: hds.space.px8, minWidth: 0 },
+  queueLink: {
+    ...hds.typeStyles.ui,
+    fontSize: hds.fontSize.xs,
+    color: 'var(--semantic-color-content-primary)',
+    textDecoration: 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  queueNum: {
+    fontFamily: hds.monoFamily,
+    color: 'var(--semantic-color-content-secondary)',
+    fontVariantNumeric: 'tabular-nums',
+  },
+} satisfies Record<string, CSSProperties>;

--- a/src/app/pages/ops/tasks/TasksPage.tsx
+++ b/src/app/pages/ops/tasks/TasksPage.tsx
@@ -30,6 +30,7 @@ import { useTasks } from './useTasks';
 import { useTaskActions } from './useTaskActions';
 import { useTaskSelection } from './useTaskSelection';
 import { TaskRow } from './TaskRow';
+import { RalphPanel } from './RalphPanel';
 import { groupTasksNow, type GroupBy } from './taskMeta';
 import type { TaskStatus } from './types';
 
@@ -135,6 +136,8 @@ export default function TasksPage() {
           refresh
         </Button>
       </div>
+
+      <RalphPanel />
 
       {sourceFilters.length > 2 && (
         <div style={s.sourceRow}>

--- a/tests/api/github-issues.test.ts
+++ b/tests/api/github-issues.test.ts
@@ -256,3 +256,90 @@ describe('makeGitHubPort().addLabel — pull request URLs (ops#137 review findin
     expect(url).toBe('https://api.github.com/repos/hirobius/ops/issues/99/labels');
   });
 });
+
+describe('makeGitHubPort() — Ralph fleet reads (ops#112)', () => {
+  beforeEach(() => {
+    vi.stubEnv('GITHUB_TOKEN', 'test-token');
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('listRalphRuns: one Actions query per repo, normalized, newest first', async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      pageResponse({
+        workflow_runs: [
+          {
+            run_number: 69,
+            status: 'in_progress',
+            conclusion: null,
+            display_title: 'Ralph 69',
+            html_url: `https://github.com/${/repos\/([^/]+\/[^/]+)\//.exec(url)![1]}/actions/runs/1`,
+            run_started_at: '2026-07-12T04:00:00Z',
+          },
+        ],
+      } as never),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await makeGitHubPort()!.listRalphRuns({ repos: ['hirobius/ops', 'hirobius/hds'] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      '/repos/hirobius/ops/actions/workflows/ralph.yml/runs',
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      repo: 'hirobius/ops',
+      runs: [{ number: 69, status: 'in_progress', conclusion: null, title: 'Ralph 69' }],
+    });
+  });
+
+  it('listRalphRuns: a failing repo yields an error entry, not a thrown batch', async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      String(url).includes('/hds/')
+        ? ({
+            ok: false,
+            status: 404,
+            text: async () => 'nope',
+            headers: { get: () => null },
+          } as never)
+        : pageResponse({ workflow_runs: [] } as never),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await makeGitHubPort()!.listRalphRuns({ repos: ['hirobius/ops', 'hirobius/hds'] });
+    expect(out[0]).toMatchObject({ repo: 'hirobius/ops', runs: [] });
+    expect(out[1].repo).toBe('hirobius/hds');
+    expect(out[1].error).toContain('404');
+  });
+
+  it('listRalphReadyIssues: queries labels=ralph-ready per repo, drops PRs, normalizes', async () => {
+    const fetchMock = vi.fn(async () =>
+      pageResponse([
+        { ...rawIssue(7), labels: [{ name: 'ralph-ready' }, { name: 'p1' }] },
+        { ...rawIssue(8), labels: [{ name: 'ralph-ready' }], pull_request: {} },
+      ] as never),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await makeGitHubPort()!.listRalphReadyIssues({ repos: ['hirobius/ops'] });
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('labels=ralph-ready');
+    expect(out).toEqual([
+      {
+        repo: 'hirobius/ops',
+        issues: [
+          {
+            repo: 'hirobius/ops',
+            number: 7,
+            title: 'issue 7',
+            url: 'https://github.com/hirobius/ops/issues/7',
+            labels: ['ralph-ready', 'p1'],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/tests/api/ralph-queue.test.ts
+++ b/tests/api/ralph-queue.test.ts
@@ -1,0 +1,63 @@
+/**
+ * lib/tasks/ralph-queue.mjs — the panel's queue MUST mirror the deterministic
+ * selector (ralph/next.sh:26-32): p0→p3 then ascending issue number, unlabeled
+ * last; blocked/needs-adrian/ralph-parked never appear; ralph-wip is annotated
+ * (it's being worked — the runs lane shows it) but keeps its slot.
+ */
+import { describe, it, expect } from 'vitest';
+import { orderRalphQueue } from '../../lib/tasks/ralph-queue.mjs';
+
+function issue(repo: string, number: number, labels: string[] = []) {
+  return {
+    repo,
+    number,
+    title: `t${number}`,
+    url: `https://github.com/${repo}/issues/${number}`,
+    labels,
+  };
+}
+
+describe('orderRalphQueue — selector parity', () => {
+  it('orders by p-label (p0→p3) then ascending issue number, unlabeled last', () => {
+    const out = orderRalphQueue([
+      issue('hirobius/ops', 200),
+      issue('hirobius/ops', 150, ['p2']),
+      issue('hirobius/ops', 140, ['p1']),
+      issue('hirobius/ops', 130),
+      issue('hirobius/ops', 120, ['p1']),
+      issue('hirobius/ops', 300, ['p0']),
+    ]);
+    expect(out.map((i) => i.number)).toEqual([300, 120, 140, 150, 130, 200]);
+  });
+
+  it('excludes blocked / needs-adrian / ralph-parked, exactly like next.sh', () => {
+    const out = orderRalphQueue([
+      issue('hirobius/ops', 1, ['p0', 'blocked']),
+      issue('hirobius/ops', 2, ['needs-adrian']),
+      issue('hirobius/ops', 3, ['ralph-parked', 'p1']),
+      issue('hirobius/ops', 4, ['p3']),
+    ]);
+    expect(out.map((i) => i.number)).toEqual([4]);
+  });
+
+  it('annotates ralph-wip (being worked) without dropping or reordering it', () => {
+    const out = orderRalphQueue([
+      issue('hirobius/ops', 5, ['p1', 'ralph-wip']),
+      issue('hirobius/ops', 6, ['p1']),
+    ]);
+    expect(out.map((i) => [i.number, i.wip])).toEqual([
+      [5, true],
+      [6, false],
+    ]);
+  });
+
+  it('carries prio + repo through for rendering', () => {
+    const [a] = orderRalphQueue([issue('hirobius/hds', 9, ['p2', 'enhancement'])]);
+    expect(a.prio).toBe('p2');
+    expect(a.repo).toBe('hirobius/hds');
+  });
+
+  it('empty input → empty queue', () => {
+    expect(orderRalphQueue([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Linked unit

Unit: n/a (orchestration retired). Closes #112 (session-claimed per Adrian — "I want to see the board live").

## Summary

`/ops/tasks` gains a **RALPH — FLEET** panel answering "which Ralphs are running?" at a glance, polling `GET /api/tasks?ralph=1` every 45s (folded into the existing function — Hobby cap intact, GitHub is the only store consulted since labels ARE the loop's state). Per fleet repo (ops/hds/site-engine): the latest Ralph run as a toned, linked chip — running / idle-with-last-green / failure. Below: the cross-repo queue in the **exact deterministic selector order** — new pure `lib/tasks/ralph-queue.mjs` mirrors `ralph/next.sh:26-32` (p0→p3 then issue #; blocked/needs-adrian/ralph-parked excluded; ralph-wip kept in-slot, marked "working") and is unit-tested against that parity. Per-repo GitHub failures render as their own red line naming the fix (e.g. missing Actions permission) — one broken repo never blanks the panel.

## Validator output

```
vitest: 46 files, 530 tests green (8 new: 5 selector-parity + 3 port normalization/fail-soft)
vite build green · layout-integrity 16/16 · typecheck + typecheck:api clean
pre-commit full registry chain + pre-push ran green (no --no-verify)
DOM-node-budget baseline ratcheted via --update (panel adds one page element)
```

## Breaking change

- [ ] No — additive panel + additive query param.

## Screenshots (if visual)

- [x] Attached in the session thread (fixture-driven: ops running, hds idle-green, site-engine failure + error line, ordered queue with prio/working chips).

## Checklist

- [x] `Co-Authored-By` trailer present
- [ ] Orchestration — n/a, retired
- [x] No `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJTnxELCPyj3r288Q6TpCE)_