### PR TITLE
ci(ralph): hourly idle watchdog + kit re-sync

### DIFF
--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -7,10 +7,14 @@ name: Ralph
 # Triggers: manual dispatch (optionally naming an issue — a human override
 # that steals any claim), `issues: labeled` (fires when something is tagged
 # ralph-ready; the guard filters every other label — load-bearing, see the
-# reusable), and push-to-main (the chain: an approved+merged Ralph PR pushes
-# main, which grabs the next issue). Selection, claiming, single-flight,
-# wedge alerts, and reconciliation all live in the reusable workflow +
-# ralph/lib.sh — one logic for CI and local runs.
+# reusable), push-to-main (the chain: an approved+merged Ralph PR pushes
+# main, which grabs the next issue), and an hourly schedule (the idle
+# watchdog: the event-driven chain halts silently after a failed iteration,
+# and label runs queued behind an in-flight run are cancelled by the
+# concurrency dedup — the tick re-enters the guard and restarts the queue;
+# an idle tick with nothing to do is a quiet no-op). Selection, claiming,
+# single-flight, wedge alerts, and reconciliation all live in the reusable
+# workflow + ralph/lib.sh — one logic for CI and local runs.
 #
 # ops is private client automation — correctness over speed, no destructive
 # ops, merges are human-approved (`ralph-approved` on the PR, or the issue
@@ -27,6 +31,8 @@ on:
     types: [labeled]
   push:
     branches: [main] # chain: a merged Ralph PR grabs the next ralph-ready issue
+  schedule:
+    - cron: "11 * * * *" # idle watchdog (staggered minute; site-engine/hds use others)
 
 concurrency:
   group: ralph-${{ github.repository }}

--- a/ralph/lib.sh
+++ b/ralph/lib.sh
@@ -255,7 +255,7 @@ park_issue() {
 # what actually happened, regardless of how the work step died. Prints one
 # token: pr:<num> | parked:<why> | failed:<why>. Never returns non-zero.
 reconcile_issue() {
-  local n=$1 run_id=$2 work_status=$3 all pr closed branch i fails why
+  local n=$1 run_id=$2 work_status=$3 all pr closed branch i fails why eligible
   all=$(gh pr list --state all --limit 200 --json number,headRefName,state \
     --jq "[.[] | select(.headRefName | startswith(\"ralph/issue-$n-\"))]" \
     2>/dev/null || echo '[]')
@@ -298,7 +298,26 @@ Opened by ralph reconciliation (run \`$run_id\`): the iteration pushed this bran
   else
     why="${why:-iteration ended without a pushed branch ($work_status)}"
   fi
-  # 3) Nothing shippable → record the attempt, release the claim, park on cap.
+  # 3) Deliberate stop, not a failure: prompt.md tells the model "blocked or
+  #    ambiguous → comment on the issue and STOP", which reaches here as
+  #    "no branch pushed" — but the model (or a human, mid-run) took the issue
+  #    out of the queue: closed it, pulled the ready label, or tagged it
+  #    needs-adrian / blocked. Recording an attempt would double-count one
+  #    decision, and needs-adrian often rides ALONGSIDE a kept ready label, so
+  #    no re-label event ever resets that budget. On API failure assume
+  #    "queued" and fall through to the conservative attempt-recording path.
+  eligible=$(gh issue view "$n" --json state,labels 2>/dev/null |
+    jq -r --arg l "$RALPH_READY_LABEL" \
+      'if .state != "OPEN" then "closed"
+       elif ([.labels[].name] | index($l)) == null then "unqueued"
+       elif ([.labels[].name] | (index("needs-adrian") or index("blocked"))) then "handed off"
+       else "queued" end' 2>/dev/null || echo queued)
+  if [ "$eligible" != "queued" ]; then
+    release_claim "$n"
+    echo "parked:#$n was $eligible during the iteration ($why) — deliberate stop, no attempt recorded"
+    return 0
+  fi
+  # 4) Nothing shippable → record the attempt, release the claim, park on cap.
   record_failed_attempt "$n" "$run_id" "$why"
   release_claim "$n"
   fails=$(count_failed_attempts "$n")


### PR DESCRIPTION
## Why

The whole fleet went idle 2026-07-12 (ops, hds, site-engine all `IDLE` with queued work, including P0s) because the event-driven Ralph chain has no recovery when it stops for any reason other than a merge:

- A failed iteration ends its run red and nothing re-fires.
- `issues: labeled` runs queued behind an in-flight run are cancelled by the concurrency dedup and never replayed.

## Changes

- **`.github/workflows/ralph.yml`** — add `schedule: "11 * * * *"` (staggered minute; site-engine uses 23, hds 41). The tick re-enters the reusable's guard: empty queue / healthy in-flight PR → quiet skip; wedged → Discord alert; ready work + idle loop → claim + dispatch hop. Costs one guard step when idle.
- **`ralph/lib.sh`** — re-synced byte-identical from the engine kit (`hirobius/ralph@v1`, already merged). `reconcile_issue` now classifies a deliberate blocked-stop (no branch pushed + issue left the queue mid-run: closed / un-readied / needs-adrian / blocked) as a green park with no attempt burned.

Engine support (schedule-event chain hop) merged in hirobius/ralph#13 → `main` + `v1`, so the ralph-gate kit-drift check passes against a matching canonical kit. Same change already merged in site-engine#124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2Qtbw8hJJ54UwcU4hoy7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2Qtbw8hJJ54UwcU4hoy7D)_