### PR TITLE
chore(schema): re-sync vendored ClientConfig — section variants (site-engine #134)

### DIFF
--- a/lib/schema/index.mjs
+++ b/lib/schema/index.mjs
@@ -63,7 +63,7 @@ export const BrandSchema = z.object({
  * a design that can't be expressed as a variant is a custom engagement.
  */
 export const SECTION_VARIANTS = {
-  hero: ['classic', 'video'],
+  hero: ['classic', 'video', 'split-card', 'banner'],
   services: ['grid'],
   gallery: ['grid'],
   reviews: ['cards'],

--- a/lib/schema/index.mjs
+++ b/lib/schema/index.mjs
@@ -56,11 +56,49 @@ export const BrandSchema = z.object({
   motion: z.enum(['none', 'subtle', 'rich']).default('rich'),
 });
 
+/**
+ * Section style variants (vendored from site-engine
+ * `packages/schema/src/section-variants.ts`). First value = default = the
+ * classic design; ids are layout adjectives, never trade names. Closed set —
+ * a design that can't be expressed as a variant is a custom engagement.
+ */
+export const SECTION_VARIANTS = {
+  hero: ['classic', 'video'],
+  services: ['grid'],
+  gallery: ['grid'],
+  reviews: ['cards'],
+  serviceAreaMap: ['standard'],
+  contact: ['standard'],
+};
+
+/** `{ variant }` object for one section, defaulting to the classic design. */
+function sectionVariant(id) {
+  const values = SECTION_VARIANTS[id];
+  return z.object({ variant: z.enum(values).default(values[0]) }).default({});
+}
+
 export const LayoutSchema = z.object({
+  /**
+   * @deprecated Legacy hero variant switch — prefer
+   * `layout.sections.hero.variant`; `defineClient()` maps 'B' onto 'video'
+   * when no explicit hero variant is set.
+   */
   variant: z.enum(['A', 'B']).default('A'),
   sectionOrder: z
     .array(z.enum(['services', 'gallery', 'reviews', 'serviceAreaMap', 'contact']))
     .default(['services', 'gallery', 'reviews', 'serviceAreaMap', 'contact']),
+  /** Per-section style variants (closed enums). Fully defaulted; strict. */
+  sections: z
+    .object({
+      hero: sectionVariant('hero'),
+      services: sectionVariant('services'),
+      gallery: sectionVariant('gallery'),
+      reviews: sectionVariant('reviews'),
+      serviceAreaMap: sectionVariant('serviceAreaMap'),
+      contact: sectionVariant('contact'),
+    })
+    .strict()
+    .default({}),
 });
 
 export const ServiceSchema = z.object({
@@ -142,8 +180,28 @@ export const ClientConfigSchema = z.object({
  * @param {unknown} config
  * @returns {object} the validated, normalized ClientConfig
  */
+/**
+ * Bridge the deprecated `layout.variant` hero switch onto the variant system:
+ * 'B' resolves to `layout.sections.hero.variant = 'video'` unless the config
+ * sets an explicit hero variant, which wins. 'A' is the 'classic' default.
+ * @param {any} config
+ */
+function applyLegacyHeroVariant(config) {
+  const layout = config?.layout;
+  if (!layout || layout.variant !== 'B' || layout.sections?.hero?.variant) {
+    return config;
+  }
+  return {
+    ...config,
+    layout: {
+      ...layout,
+      sections: { ...layout.sections, hero: { variant: 'video' } },
+    },
+  };
+}
+
 export function defineClient(config) {
-  const result = ClientConfigSchema.safeParse(config);
+  const result = ClientConfigSchema.safeParse(applyLegacyHeroVariant(config));
   if (!result.success) {
     const issues = result.error.issues
       .map((i) => `  • ${i.path.join('.') || '(root)'}: ${i.message}`)


### PR DESCRIPTION
Companion to hirobius/site-engine#134 (merged). Two commits re-syncing the vendored `lib/schema/index.mjs` with the canonical schema: `SECTION_VARIANTS` registry, `layout.sections.<id>.variant` closed enums (fully defaulted, strict), the legacy `layout.variant "B"` → hero `"video"` bridge in `defineClient()`, and the harvested `split-card`/`banner` hero enum values.

Left for Adrian to merge (one tap) since ops CLAUDE.md's hard rule reserves writes to `main` for humans. Until merged, the ops agent simply can't emit the two new hero variants — defaults still validate fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ab11dmwHY63YAf5rJTdaE

---
_Generated by [Claude Code](https://claude.ai/code/session_017ab11dmwHY63YAf5rJTdaE)_