### PR TITLE
guardrails+ci: fix proof-of-firing cache bug (#180) + disable hourly Ralph cron

### DIFF
--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -31,8 +31,11 @@ on:
     types: [labeled]
   push:
     branches: [main] # chain: a merged Ralph PR grabs the next ralph-ready issue
-  schedule:
-    - cron: "11 * * * *" # idle watchdog (staggered minute; site-engine/hds use others)
+  # schedule: DISABLED 2026-07-16 — the hourly idle watchdog moved to the local
+  #   runner (ops#214) to stop spending GitHub Actions minutes. workflow_dispatch
+  #   stays as the manual escape hatch. Re-enable this block to revert to
+  #   CI-driven Ralph.
+  #   - cron: "11 * * * *" # idle watchdog (staggered minute; site-engine/hds use others)
 
 concurrency:
   group: ralph-${{ github.repository }}

--- a/scripts/validate-fixture-proof-of-firing.mjs
+++ b/scripts/validate-fixture-proof-of-firing.mjs
@@ -274,10 +274,15 @@ function validate() {
       cached.passingMtime === passingMtime &&
       cached.lastResult !== undefined
     ) {
-      // Cache hit — skip re-run
-      if (cached.lastResult === 'pass') {
-        real.push({ id: gateId, fromCache: true });
-      } else {
+      // Cache hit — skip re-run. Every cached real-fixture gate counts toward
+      // `real` (attempted), mirroring the fresh path which pushes to `real`
+      // before running. Only a cached 'fail' is a proof-of-firing failure; a
+      // cached 'skip' (gate not runnable in this environment — e.g. an optional
+      // tool like gitleaks is absent) is accounted-for, exactly as a fresh skip
+      // is. The previous code mis-counted any non-'pass' cached result
+      // (including 'skip') as a failure, so the cache disagreed with a fresh run.
+      real.push({ id: gateId, fromCache: true });
+      if (cached.lastResult === 'fail') {
         failures.push({ id: gateId, reason: 'cached failure', fromCache: true });
       }
       newCache[gateId] = cached;


### PR DESCRIPTION
## Linked issue

Closes #180. Relates to #214 (local runner), #206 (cross-repo guardrail drift).

## Summary

Two changes:
1. **Proof-of-firing cache bug** — on a cache hit, any `lastResult` other than `pass` (including `skip`, e.g. gitleaks absent) was counted as a proof-of-firing failure, so a *second* cached run went red while `--no-cache` stayed green. Now every cached real gate counts as attempted and only a cached `fail` is a failure — matching a fresh run. (This is the fix hds already carried; see #206.)
2. **Disable the hourly Ralph `schedule:` cron** in `ralph.yml` — the idle watchdog moves to the local runner (#214) to stop spending GitHub Actions minutes. `workflow_dispatch` + `issues: labeled` + `push: main` stay intact.

## Validator output

```
$ node scripts/validate-fixture-proof-of-firing.mjs --no-cache
[validate-fixture-proof-of-firing] ✓ All 46 gates accounted for (10 real, 34 stubs)   → exit 0

$ node scripts/validate-fixture-proof-of-firing.mjs        # 2nd cached run
[validate-fixture-proof-of-firing] ✓ All 46 gates accounted for   → exit 0
   (before this PR: exit 1 — 3 cached 'skip' results mis-counted as failures)
```
Pre-commit gate ran on commit; no `--no-verify`.

## Breaking change

- [ ] Introduces a breaking change — **No.** Validator counting fix + CI-trigger change only.

## Screenshots (if visual)

- [x] N/A — non-visual.

## Checklist

- [x] Conventional commit + `Co-Authored-By` trailer.
- [x] No `--no-verify` used.

> ⚠️ The `schedule` disable only takes effect once merged to the default branch (GitHub reads schedule/issue triggers from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAnaoF3KCby44288jSgQ3a

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAnaoF3KCby44288jSgQ3a)_