### PR TITLE
fix(lead-gen): read Outscraper `website` field, not `site` — every lead was mis-qualified

### DIFF
--- a/lib/lead-gen/index.mjs
+++ b/lib/lead-gen/index.mjs
@@ -129,10 +129,15 @@ async function sourceViaOutscraper(query, { limit, apiKey }) {
  * @returns {SourcedLead}
  */
 function mapPlace(p, { niche, city, region, metro }) {
-  const website = p.site || null;
+  // Outscraper's Google-Maps field is `website` (NOT `site`). Verified against
+  // live /maps/search-v3 output 2026-07 — the old `p.site` was always undefined,
+  // so every lead was mis-flagged has_website:false / qualified:true. This is the
+  // qualifier the whole pipeline keys on, so the field name is load-bearing.
+  const website = p.website || p.site || null;
   const place_id =
     p.place_id || p.google_id || `outscraper-${slug(p.name || niche)}-${slug(p.full_address || metro)}`;
-  // ⚠️ VERIFY enriched email field name against Outscraper docs.
+  // Verified against live enrichment (enrichment=domains_service): the primary
+  // email lands in `email_1`; `emails` array is a legacy fallback.
   const email = p.email_1 || (Array.isArray(p.emails) ? p.emails[0] : null) || null;
 
   return {


### PR DESCRIPTION
## The bug

`lib/lead-gen/index.mjs` `mapPlace()` read the business website from **`p.site`**, but Outscraper's `/maps/search-v3` returns it as **`website`**. `p.site` is always `undefined`, so every sourced lead came back:

```js
has_website: false,   // wrong
qualified:   true,    // wrong — "no website → needs one built"
```

`qualified` is the single signal the whole lead → site funnel keys on, so this silently marked **every** business — including ones with polished existing sites — as a qualified no-website prospect.

## Evidence (live pull)

Ran a real `/maps/search-v3` pull from a remote session ("pressure washing in Tacoma, WA", 20 results). With the old `p.site` logic: **20/20 "qualified."** Filtering on the actual `website` field: **18/20 have websites**, only 2 are truly website-less. Confirmed the field name against the raw records (Orca ProWash → `website: "https://orcaprowash.com/"`, etc.).

## Fix

- `const website = p.website || p.site || null;` (keeps `site` as a harmless fallback in case a future provider swap uses it).
- Marked the email field verified: live `enrichment=domains_service` puts the primary contact in `email_1` (the `emails` array is the legacy fallback) — resolves the adjacent `⚠️ VERIFY` note.

No behavior change beyond the corrected field read; `has_website` / `qualified` / `qualify_reason` now reflect reality.

## Verify

- `node --check lib/lead-gen/index.mjs` — OK
- Module loads, `pullLeads` exported
- Field name cross-checked against live Outscraper output (not docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAnaoF3KCby44288jSgQ3a)_