### PR TITLE
docs(legal+ops): MSA/SOW templates + running build log

### DIFF
--- a/docs/legal/MSA-template.md
+++ b/docs/legal/MSA-template.md
@@ -1,0 +1,112 @@
+# Master Services Agreement (Template)
+
+> **Not legal advice.** This is a plain-English starting template for a solo
+> marketing agency. Have a licensed attorney in your state review and adapt it
+> before use. Fill every `[bracketed]` field. Pair it with a per-engagement
+> **Statement of Work (SOW)** — the MSA sets the rules; each SOW sets the work,
+> fees, and any guarantees.
+
+**This Master Services Agreement ("Agreement")** is entered into as of
+`[Effective Date]` between:
+
+- **Hirobius** `[legal entity name, e.g. Hirobius LLC]`, `[state]` (the "Agency"), and
+- `[Client legal name]` (the "Client").
+
+## 1. Services
+The Agency will provide marketing services as described in one or more
+**Statements of Work (SOWs)** that reference this Agreement. Each SOW is
+incorporated into this Agreement when signed by both parties. If an SOW
+conflicts with this Agreement, the SOW controls for that engagement.
+
+## 2. Term & Termination
+- This Agreement starts on the Effective Date and continues until terminated.
+- Each SOW states its own initial term; after the initial term, work continues
+  **month-to-month**.
+- Either party may terminate an SOW for convenience with **`[14]` days' written
+  notice**. Either party may terminate immediately for a material breach the
+  other fails to cure within **`[10]` days** of written notice.
+- On termination: the Client pays for work performed and costs committed through
+  the termination date; the Agency hands off access and deliverables produced
+  and paid for.
+
+## 3. Fees & Payment
+- Fees are stated in each SOW. Setup fees are due before work begins unless the
+  SOW says otherwise. Monthly retainers are billed **in advance** on the
+  `[1st]` of each month.
+- **Ad spend is separate** and is billed **directly to the Client** by the ad
+  platforms (Meta, Google) on the Client's own payment method. The Agency does
+  not mark up or hold ad spend.
+- Invoices are due **`[on receipt / net 7]`**. Late amounts past `[15]` days may
+  pause work until paid.
+- Refunds apply only where a specific SOW guarantee provides for one.
+
+## 4. Client Responsibilities
+The Client will, in a timely way: provide accurate business information and any
+documents needed; capture and deliver footage/photos where the SOW calls for it;
+respond to and pursue leads promptly; approve creative and offers; keep any
+required license and insurance current; and maintain ownership of and admin
+access to its own platform accounts (see §6). Delays here may shift timelines.
+
+## 5. Independent Contractor
+The Agency is an independent contractor, not an employee, partner, or joint
+venturer of the Client. Each party pays its own taxes and expenses.
+
+## 6. Accounts, Data & Intellectual Property
+- **Client accounts.** All advertising, listing, analytics, and business
+  accounts (e.g., Google Business Profile, Meta Business Manager and ad
+  accounts, Google Ads, GA4) are **owned by the Client**. The Agency operates
+  them as an **admin/manager**, never as owner, and never runs Client ads on the
+  Agency's personal ad accounts. On termination, the Agency's access is removed
+  and ownership stays with the Client.
+- **Client data.** The Client is the data controller of its own customer and
+  business data. The Agency processes it only to perform the Services.
+- **Deliverables.** On full payment for a given deliverable (ads, creative,
+  copy, tracking setup), the Client receives a license to use it for its
+  business. The Agency retains ownership of its pre-existing tools, templates,
+  frameworks, and know-how (including the Hirobius portal/design system), and may
+  reuse them for other clients.
+- **Footage license.** The Client grants the Agency a license to use footage,
+  photos, and job media the Client provides, for the purpose of producing and
+  running the Client's ads and case studies, unless the SOW says otherwise.
+
+## 7. Confidentiality
+Each party will protect the other's non-public business information and use it
+only to perform or receive the Services. This survives termination.
+
+## 8. Guarantees & No Guarantee of Results
+Any guarantee is stated **explicitly in an SOW** (for example, a listing-
+reinstatement refund). Except for those, the Agency does **not** guarantee any
+specific result, lead count, ranking, or revenue — results depend on factors
+outside the Agency's control (platform decisions, market, the Client's own
+follow-up). The Agency guarantees the work, the timelines stated, and full
+transparency.
+
+## 9. Third-Party Platforms
+The Services rely on third-party platforms (Meta, Google, etc.) with their own
+terms, pricing, and enforcement. The Agency is not responsible for platform
+outages, policy changes, account actions, or costs charged by those platforms,
+beyond performing the Services with reasonable care.
+
+## 10. Limitation of Liability
+To the extent allowed by law: neither party is liable for indirect, incidental,
+or consequential damages; and the Agency's total liability under an SOW is
+capped at the **fees the Client paid the Agency under that SOW in the prior
+`[3]` months** (excluding ad spend). Nothing limits liability for fraud or
+willful misconduct.
+
+## 11. General
+- **Governing law:** `[State]`, USA. Disputes are handled in the courts of
+  `[County, State]`.
+- **Entire agreement:** this Agreement plus signed SOWs is the entire agreement
+  and replaces prior discussions. Changes must be in writing and signed.
+- **Assignment:** neither party may assign without the other's consent, except
+  to a successor of its business.
+- **Notices:** by email to the addresses the parties use for the engagement.
+- **Severability:** if a provision is unenforceable, the rest stays in effect.
+
+**Signatures**
+
+| Agency | Client |
+|---|---|
+| `[Name]`, Hirobius | `[Name]`, `[Client]` |
+| Signature / Date | Signature / Date |

--- a/docs/legal/SOW-template.md
+++ b/docs/legal/SOW-template.md
@@ -1,0 +1,50 @@
+# Statement of Work (Template)
+
+> **Not legal advice.** Generic template — fill every `[bracketed]` field and
+> have counsel review before use. This SOW is governed by the Hirobius Master
+> Services Agreement (MSA) between the parties.
+
+**SOW #:** `[001]` · **Date:** `[YYYY-MM-DD]`
+**Client:** `[Client legal name]` · **Contact:** `[Name, email]`
+**Governed by:** Hirobius MSA dated `[Effective Date]`
+
+## 1. Scope of Work
+`[Plain-language description of what the Agency will deliver this engagement.]`
+
+Deliverables:
+- `[Deliverable 1]`
+- `[Deliverable 2]`
+- `[…]`
+
+## 2. Fees & Schedule
+| Item | Amount | When |
+|---|---|---|
+| `[One-time / setup]` | `[$X]` | `[before work begins]` |
+| `[Monthly retainer]` | `[$X/mo]` | `[in advance, 1st of month]` |
+| Ad budget | `[$X–Y/mo]` | billed **directly to Client** by Meta/Google |
+
+**Initial term:** `[3 months]`, then month-to-month. **Ad spend is separate**
+and never touches the Agency's accounts.
+
+## 3. Guarantees (this SOW only)
+`[State any explicit guarantee, e.g. "If the suspended Google listing is not
+reinstated, the $[X] repair fee is fully refunded." Otherwise: "No guarantee of
+specific results; see MSA §8."]`
+
+## 4. Client Responsibilities
+- `[e.g. provide reinstatement documents]`
+- `[e.g. capture before/after footage on each job]`
+- `[e.g. respond to leads quickly]`
+- `[e.g. keep license/insurance current; own & grant admin on ad accounts]`
+
+## 5. Assumptions & Exclusions
+- Excludes: `[e.g. full website rebuild, professional video production, added
+  channels]` — quoted separately.
+- Assumes: `[e.g. timely approvals and access from the Client]`.
+
+## 6. Acceptance
+Work begins when this SOW is signed and any setup fee is received.
+
+| Agency | Client |
+|---|---|
+| `[Name]`, Hirobius · Date | `[Name]`, `[Client]` · Date |

--- a/docs/ops/build-log.md
+++ b/docs/ops/build-log.md
@@ -17,6 +17,9 @@
   (local/gitignored; meta, retainer, checklist, tasks, goals, status).
 - **Legal templates** — `docs/legal/MSA-template.md` + `SOW-template.md`
   (reusable; filled Access Tech version handed to Adrian separately).
+- **Determinism & autonomy audit** — 46 gates (27 enforced / 19 manual), Ralph
+  idle-watchdog found DISABLED (the bottleneck), `--no-verify` gate hole, token
+  source of truth already exists. Published as an artifact; findings below.
 - **This build log.**
 
 ## Decisions
@@ -42,6 +45,14 @@
    copies); an evals workstream to harden site-engine's LLM generation.
 8. **`access-tech-internal` repo → private** (portal content was readable on a
    public repo despite the password gate).
+
+## Audit findings (2026-09-12) → punch list
+1. **Re-arm the Ralph idle-watchdog** (dial: A cloud cron every ~3h [rec] · B reliable local runner · C manual=status quo). PENDING Adrian.
+2. Fix the `--no-verify` hole — editorconfig-checker skip-when-unavailable so remote sessions keep every pre-commit gate. (Claude, branch+PR)
+3. Codify the Operating Contract → `~/.claude/CLAUDE.md` + client-repo CLAUDE.md.
+4. Promote the top ~6 manual gates to CI; mark the rest advisory in the registry.
+5. Add 3 cross-repo gates: client-repo privacy · portal client-safe lint · token-drift guard.
+6. Token unification — portal-kit + Lilac consume `hirobius.tokens.json`.
 
 ## Open / to validate at end of push
 - [ ] Access Tech workspace extracted into desktop `clients/access-tech/` +

--- a/docs/ops/build-log.md
+++ b/docs/ops/build-log.md
@@ -1,0 +1,57 @@
+# Build & Decision Log — Access Tech launch + agency-OS hardening
+
+> Running log of what we built and the decisions we made this push, so we can
+> validate at the end that we did the right things. Newest entries at the top of
+> each section. Started 2026-09-11.
+
+## Built
+- **Access Tech client portal** (`access-tech-internal`, powered by `portal-kit`):
+  single gated page — proposal, "Why This Strategy", DIY appeal guide, roadmap,
+  filming guide; document reader with callouts + collapsible sections;
+  cross-doc links; Copy-for-AI (top + bottom); dark/light + iOS fixes;
+  Vercel Web Analytics (raw script, zero-dependency).
+- **portal-kit** shared static renderer (`theme.css` + `portal.js`): the reusable
+  engine behind every client portal — markdown extras (`::: collapsible :::`,
+  `> callout`, `[text](#doc)` cross-links), theme switcher, full-screen reader.
+- **Access Tech CRM workspace** onboarded into `ops/clients/access-tech/`
+  (local/gitignored; meta, retainer, checklist, tasks, goals, status).
+- **Legal templates** — `docs/legal/MSA-template.md` + `SOW-template.md`
+  (reusable; filled Access Tech version handed to Adrian separately).
+- **This build log.**
+
+## Decisions
+1. **Profile-repair price = $400** — fair (market $300–800), refund-guaranteed,
+   with a free DIY option; not the market floor, not gouging.
+2. **Design system: unify tokens, not framework.** Client portals + Lilac stay
+   vanilla/static (bulletproof, no build); ops stays React/HDS. One DTCG token
+   source → generated CSS vars (portals) + React components (ops). Same visual
+   language everywhere; right runtime per surface.
+3. **All clients live in `ops/clients/`** — gitignored (PII-safe), rendered on
+   `/ops/clients/<slug>`. Client *delivery* tasks live in the workspace
+   `tasks.json`; the GitHub board stays for building the OS itself.
+4. **Autonomy relaxed** — Claude pushes. ops changes go via `claude/*` branch +
+   PR (never direct to prod `main`); client repos push freely.
+5. **Operating Contract** adopted (autonomy tiers by blast radius; act-then-
+   report; batch questions into one list). To be codified into auto-loading
+   `CLAUDE.md` / user memory.
+6. **Determinism = Codify + Enforce + Route.** Encode rules where they auto-load;
+   gate the mechanizable ones; route decisions to a batched `needs-adrian` queue.
+7. **Adopt Matt Pocock / AI Hero pieces:** git-guardrails hook (tuned to block
+   destructive git, allow normal push); re-arm Ralph + Docker Sandbox for
+   unattended runs; `/writing-for-agents`; the skills plugin (supersede vendored
+   copies); an evals workstream to harden site-engine's LLM generation.
+8. **`access-tech-internal` repo → private** (portal content was readable on a
+   public repo despite the password gate).
+
+## Open / to validate at end of push
+- [ ] Access Tech workspace extracted into desktop `clients/access-tech/` +
+      renders on `/ops/clients/access-tech`.
+- [ ] MSA + SOW reviewed by counsel; filled Access Tech agreement sent to Phil.
+- [ ] `access-tech-internal` repo set to **private** (Adrian).
+- [ ] Vercel Web Analytics **enabled** in the project (Adrian).
+- [ ] git-guardrails hook installed with the tuned blocklist (Adrian, at terminal).
+- [ ] Determinism / autonomy audit run (next).
+- [ ] Design-token unification built (portal-kit + Lilac ← one source).
+- [ ] Operating Contract codified into auto-loading memory / `CLAUDE.md`.
+- [ ] Ralph loop re-arm decision (autonomy dial).
+- [ ] Hirobius internal agent — backlog idea.


### PR DESCRIPTION
Adds the client-engagement legal templates (the real gap before Phil signs) and a running build/decision log for this push.

## What's here
- **`docs/legal/MSA-template.md`** — reusable Master Services Agreement (plain-English, solo-agency). Codifies the blind-spots we surfaced: client-owned ad accounts (Agency is admin, never owner; never runs client ads on a personal account), guarantees stated per-SOW, ad spend billed directly to the client, IP + footage license, liability cap, independent-contractor, governing law. Placeholders throughout; carries a "not legal advice — counsel review" disclaimer.
- **`docs/legal/SOW-template.md`** — per-engagement Statement of Work template (scope, fees/schedule, per-SOW guarantee, client responsibilities, exclusions, acceptance).
- **`docs/ops/build-log.md`** — running log of what we built + decisions this push (Access Tech launch + agency-OS hardening), with an open/to-validate checklist for the end of the push.

## Notes
- Docs-only; no code, no UI. Templates are generic (safe to commit); the **filled Access Tech agreement** is handed to Adrian separately, not committed (client-specific terms).
- Committed with `--no-verify` (sandbox editorconfig-checker 403 caveat, per repo notes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjpPJJrgkYMsoeA5HMirNf)_