### PR TITLE
ci(ralph): re-arm idle-watchdog as a low-frequency backstop (every 6h)

### DIFF
--- a/.github/workflows/ralph.yml
+++ b/.github/workflows/ralph.yml
@@ -31,11 +31,14 @@ on:
     types: [labeled]
   push:
     branches: [main] # chain: a merged Ralph PR grabs the next ralph-ready issue
-  # schedule: DISABLED 2026-07-16 — the hourly idle watchdog moved to the local
-  #   runner (ops#214) to stop spending GitHub Actions minutes. workflow_dispatch
-  #   stays as the manual escape hatch. Re-enable this block to revert to
-  #   CI-driven Ralph.
-  #   - cron: "11 * * * *" # idle watchdog (staggered minute; site-engine/hds use others)
+  schedule:
+    # Idle-watchdog BACKSTOP, every 6h (staggered minute 11). Re-armed 2026-09-12
+    # as a low-frequency safety net BEHIND the local runner (ralph/loop.sh): the
+    # local runner drives supervised bursts; this catches a chain left wedged
+    # while that runner is off. Hourly was retired 2026-07-16 for cost — 6h keeps
+    # Actions minutes AND Claude usage negligible (most ticks no-op via the
+    # single-flight guard). Comment this block out to hand fully back to local.
+    - cron: "11 */6 * * *"
 
 concurrency:
   group: ralph-${{ github.repository }}


### PR DESCRIPTION
Re-enables the Ralph idle-watchdog (audit finding #1: the loop went dormant when the hourly cron was disabled 2026-07-16, so a stalled chain never self-restarted).

## What
- Uncomments `ralph.yml`'s `schedule:` trigger at **every 6h** (`cron: "11 */6 * * *"`, staggered minute 11) — a low-frequency **backstop behind the local runner**, not the old hourly loop.

## Why this cadence
- Hourly was retired for cost. The watchdog only needs to catch a chain left *wedged* while the local runner (`ralph/loop.sh`) is off — 6h does that.
- Cost is bounded: each tick is a quiet no-op unless there's queued `ralph-auto` work AND the chain stalled (single-flight guard). Note the cost is **Actions minutes + Claude Max quota** per real iteration, so cadence stays conservative.

## Coexists with the local runner (A + B)
- Local runner = supervised bursts (free, fast, while your PC is on).
- This cron = safety net for when it's off. The claim/single-flight guard prevents double-runs.

## Activation
- **Merging this PR turns it on.** To hand fully back to local-only, comment the block out again (documented inline).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjpPJJrgkYMsoeA5HMirNf)_